### PR TITLE
revert to non scrapy crawlers to avoid duplicate docs 

### DIFF
--- a/paasJobs/docker/crawl_and_download/run_job.sh
+++ b/paasJobs/docker/crawl_and_download/run_job.sh
@@ -50,8 +50,8 @@ function run_crawler() {
 
   set +o pipefail
 
-  echo -e "\nRUNNING AIR FORCE LIBRARY CRAWLER - SCRAPY\n"
-  ( scrapy runspider dataPipelines/gc_scrapy/gc_scrapy/spiders/air_force_spider.py -o $LOCAL_CRAWLER_OUTPUT_FILE_PATH ) \
+  echo -e "\nRUNNING AIR FORCE LIBRARY CRAWLER\n"
+  ( "$PYTHON_CMD" -m dataPipelines.gc_crawler.air_force_pubs run | tee -a "$LOCAL_CRAWLER_OUTPUT_FILE_PATH" ) \
     || echo "^^^ CRAWLER ERROR ^^^"
 
   echo -e "\nRUNNING ARMY CRAWLER\n"
@@ -66,8 +66,8 @@ function run_crawler() {
 #  ( "$PYTHON_CMD" -m dataPipelines.gc_crawler.bupers_pubs run | tee -a "$LOCAL_CRAWLER_OUTPUT_FILE_PATH" ) \
 #    || echo "^^^ CRAWLER ERROR ^^^"
 
-  echo -e "\nRUNNING DHA CRAWLER - SCRAPY\n"
-  ( scrapy runspider dataPipelines/gc_scrapy/gc_scrapy/spiders/dha_spider.py -o $LOCAL_CRAWLER_OUTPUT_FILE_PATH ) \
+  echo -e "\nRUNNING DHA CRAWLER\n"
+  ( "$PYTHON_CMD" -m dataPipelines.gc_crawler.dha_pubs run | tee -a "$LOCAL_CRAWLER_OUTPUT_FILE_PATH" ) \
     || echo "^^^ CRAWLER ERROR ^^^"
 
   echo -e "\nRUNNING DoD ISSUANCES CRAWLER\n"


### PR DESCRIPTION
Recently found out changes in doc_name will create new entry and a duplicate doc so the Scrapy conversions need to be checked for this before being used