### PR TITLE
Blacklisting certain topics

### DIFF
--- a/dataScience/src/featurization/topic_modeling.py
+++ b/dataScience/src/featurization/topic_modeling.py
@@ -1,3 +1,4 @@
+from dataScience.src.text_handling.custom_stopwords import custom_stopwords
 from gensim.models.tfidfmodel import TfidfModel
 from gensim import corpora
 import os
@@ -117,6 +118,7 @@ class Topics(object):
         word = []
         doc = doc_tfidf[0]
         for id, value in doc:
-            word.append((value, self.dictionary.get(id)))
+            if(self.dictionary.get(id) not in custom_stopwords):
+                word.append((value, self.dictionary.get(id)))
         word.sort(reverse=True)
         return word[:topn]

--- a/dataScience/src/text_handling/custom_stopwords.py
+++ b/dataScience/src/text_handling/custom_stopwords.py
@@ -13,7 +13,7 @@ custom_stopwords = [
     "subsec",
     "paragraph",
     "emphasis",
-    # "title",
+    "title",
     "date",
     "shall",
     "stat",


### PR DESCRIPTION
These changes implement post-processing to remove Blacklisted topics from being returned from the topic model .  The topic model has not been changed.  This change will make it so that blacklisted topics are skipped and the next highest ranked topic will be returned in its place.

The Blacklist can be updated at anytime, but will only be applied when the Topics are generated and written to the jsons.  **This means that for this change to show up in the application, the documents will need to be reprocessed.** @JLyons1985 @jram930 , to implement the change sooner we will need to either:
1. Patch the jsons with a script designed to only update the topics.  This would still require updating ES as well.
2. Implement a change on the front end to also remove the blacklisted topics.  This is less desirable because it will cut down the number of topics being returned from 5 to 0-4 depending on how many of the top 5 topics were blacklisted.

For awareness, there is an upcoming change to the Topic model that WILL require reprocessing the jsons as well.