### PR TITLE
Set Doc length requirements for Topics

### DIFF
--- a/common/document_parser/lib/topics.py
+++ b/common/document_parser/lib/topics.py
@@ -15,10 +15,12 @@ def extract_topics(doc_dict):
         doc_dict (dict): The output dict differs from the input
             only in that it now includes `topics_rs` as a key.
     """
-
+    MIN_TOKEN_LEN = 300 #tokens, this turns out to be roughly a half page
     doc_dict['topics_rs'] = {}
 
-    if(doc_dict['page_count'] > 1):
+    tokens = doc_dict['raw_text'].split()
+
+    if(len(tokens) <= MIN_TOKEN_LEN):
         topics = tfidf_model.get_topics(
             topic_processing(doc_dict['text'], bigrams), topn=5)
         for score, topic in topics:

--- a/common/document_parser/lib/topics.py
+++ b/common/document_parser/lib/topics.py
@@ -20,7 +20,7 @@ def extract_topics(doc_dict):
 
     tokens = doc_dict['raw_text'].split()
 
-    if(len(tokens) <= MIN_TOKEN_LEN):
+    if(len(tokens) > MIN_TOKEN_LEN):
         topics = tfidf_model.get_topics(
             topic_processing(doc_dict['text'], bigrams), topn=5)
         for score, topic in topics:

--- a/common/document_parser/lib/topics.py
+++ b/common/document_parser/lib/topics.py
@@ -3,12 +3,26 @@ from dataScience.src.text_handling.process import topic_processing
 
 
 def extract_topics(doc_dict):
-    doc_dict["topics_rs"] = {}
+    """
+    This function takes in a document dictionary, checks if it is
+    longer than 1 page, and if it is extracts up to 5 topics from
+    the text of the document.
+    Args:
+        doc_dict (dict): A dictionary containing document data.
+            Note that `page_count` and `text` must be present in
+            the dictionary.
+    Returns:
+        doc_dict (dict): The output dict differs from the input
+            only in that it now includes `topics_rs` as a key.
+    """
 
-    topics = tfidf_model.get_topics(
-        topic_processing(doc_dict["text"], bigrams), topn=5)
-    for score, topic in topics:
-        topic = topic.replace('_', ' ')
-        doc_dict["topics_rs"][topic] = score
+    doc_dict['topics_rs'] = {}
+
+    if(doc_dict['page_count'] > 1):
+        topics = tfidf_model.get_topics(
+            topic_processing(doc_dict['text'], bigrams), topn=5)
+        for score, topic in topics:
+            topic = topic.replace('_', ' ')
+            doc_dict['topics_rs'][topic] = score
 
     return doc_dict


### PR DESCRIPTION
Establish a requirement that a document must have more than 1 page to get topics.  If the document is only 1 page, the `topics_rs` field will be populated with an empty dict, otherwise it will be populated with up to 5 topics.

**For this change to take effect the jsons will need to be reprocessed**