### PR TITLE
max_thread neo4j parameter

### DIFF
--- a/dataPipelines/gc_neo4j_publisher/neo4j_publisher.py
+++ b/dataPipelines/gc_neo4j_publisher/neo4j_publisher.py
@@ -234,12 +234,11 @@ class Neo4jPublisher:
         process_query('CALL policy.createEntityNodesFromJson(' + json.dumps(entity_json) + ')')
         return
 
-    def process_dir(self, files: t.List[str], file_dir: str, q: mp.Queue) -> None:
+    def process_dir(self, files: t.List[str], file_dir: str, q: mp.Queue, max_threads: int) -> None:
         if not files:
             return
 
-        # TODO: Make max worker param adjustable and constrained to something that doesn't break runtime thread limit
-        with ThreadPoolExecutor(max_workers=10) as ex:
+        with ThreadPoolExecutor(max_workers=min(max_threads, 16)) as ex:
             futures = []
             for filename in files:
                 try:

--- a/dataPipelines/gc_neo4j_publisher/utils.py
+++ b/dataPipelines/gc_neo4j_publisher/utils.py
@@ -54,8 +54,8 @@ class Neo4jJobManager:
             pbar.update()
 
     @staticmethod
-    def process_files(files: t.List[str], file_dir: str, q: mp.Queue, publisher: Neo4jPublisher) -> None:
-        publisher.process_dir(files, file_dir, q)
+    def process_files(files: t.List[str], file_dir: str, q: mp.Queue, publisher: Neo4jPublisher, max_threads: int) -> None:
+        publisher.process_dir(files, file_dir, q, max_threads)
 
     @staticmethod
     def get_chunks(lst: t.List[t.Any], n: int) -> t.Iterable[t.List[t.Any]]:
@@ -144,7 +144,7 @@ class Neo4jJobManager:
         q = mp.Queue()
         proc = mp.Process(target=self.listener, args=(q, len(files)))
         proc.start()
-        workers = [mp.Process(target=self.process_files, args=(file_chunks[i], file_dir, q, publisher)) for i in range(n)]
+        workers = [mp.Process(target=self.process_files, args=(file_chunks[i], file_dir, q, publisher, max_threads)) for i in range(n)]
         for worker in workers:
             worker.start()
         for worker in workers:


### PR DESCRIPTION
Set the max_thread parameter in process_dir for neo4j updates to not have it hardcoded.