### PR TITLE
Hotfix/postgres json error

### DIFF
--- a/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
+++ b/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
@@ -56,8 +56,17 @@ class CrawlerStatusTracker:
                 join(VersionedDoc, Publication.name == VersionedDoc.name). \
                 filter(Publication.is_revoked == False).all()
             # extract crawler_used from metadata and de-dup the list
-            db_revoked_list = list(set([(name, json.loads(j)["crawler_used"]) for (name, j) in db_revoked]))
-            db_current_list = list(set([(name, json.loads(j)["crawler_used"]) for (name, j) in db_current]))
+            db_revoked_list = list(
+                set(
+                    [(name, json.loads(j)["crawler_used"])
+                        if isinstance(j,str)
+                        else (name,j["crawler_used"])
+                        for (name, j) in db_revoked]))
+            db_current_list = list(
+                set(
+                    [(name, json.loads(j)["crawler_used"])
+                     if isinstance(j,str) else (name, j["crawler_used"])
+                     for (name, j) in db_current]))
             for (doc, crawler) in db_current_list:
                 if doc not in self.input_doc_names and crawler in self.crawlers_downloaded:
                     print("Publication " + doc + " is now revoked")

--- a/dataPipelines/gc_db_utils/orch/models.py
+++ b/dataPipelines/gc_db_utils/orch/models.py
@@ -78,7 +78,7 @@ class VersionedDoc(AutoRepr, VersionedDocSchema, DeferredOrchReflectedBase):
             doc_location=doc_location,
             batch_timestamp=batch_timestamp,
             publication_date=parse_timestamp(doc['publication_date']),
-            json_metadata=json.dumps(doc),
+            json_metadata=doc,
             version_hash=doc['version_hash'],
             md5_hash="",
             is_ignored=False

--- a/dataPipelines/gc_ingest/tools/load/cli.py
+++ b/dataPipelines/gc_ingest/tools/load/cli.py
@@ -106,3 +106,8 @@ def local(lm: LoadManager,
         update_s3=not skip_s3_upload,
         update_db=not skip_db_update
     )
+
+@load_cli.command()
+@pass_lm
+def fix_json_metadata(lm: LoadManager):
+    lm.fix_json_metdata()

--- a/dataPipelines/gc_ingest/tools/load/utils.py
+++ b/dataPipelines/gc_ingest/tools/load/utils.py
@@ -104,6 +104,16 @@ class LoadManager:
             ts=ts
         )
 
+    def fix_json_metdata(self) -> None:
+        """ Fix Json values that were perviously entered as strings """
+        with Config.connection_helper.orch_db_session_scope('rw') as session:
+            jsons = session.query(VersionedDoc.id, VersionedDoc.json_metadata).all()
+            for (id, j_metadata) in jsons:
+                if isinstance(j_metadata, str):
+                    print(j_metadata)
+                    doc = session.query(VersionedDoc).filter_by(id=id).one()
+                    doc.json_metadata = json.loads(j_metadata)
+            session.commit()
 
     def get_ingestable_docs(self,
                             raw_dir: t.Union[Path, str],

--- a/dataPipelines/gc_ingest/tools/load/utils.py
+++ b/dataPipelines/gc_ingest/tools/load/utils.py
@@ -110,7 +110,6 @@ class LoadManager:
             jsons = session.query(VersionedDoc.id, VersionedDoc.json_metadata).all()
             for (id, j_metadata) in jsons:
                 if isinstance(j_metadata, str):
-                    print(j_metadata)
                     doc = session.query(VersionedDoc).filter_by(id=id).one()
                     doc.json_metadata = json.loads(j_metadata)
             session.commit()

--- a/dataPipelines/scripts/fix_json_metadata.sh
+++ b/dataPipelines/scripts/fix_json_metadata.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+
+# this function changes the json_metadata field of the Versioned_docs table from a string to JSON type
+# (does nothing if JSON)
+python -m dataPipelines.gc_ingest tools load \
+  --bucket-name "advana_raw_zone" \
+  --load-archive-base-prefix "gamechanger/load-archive/" \
+  fix-json-metadata
+
+# this function refreshes the view that produces the gc_document_corpus_snapshot
+
+python -m dataPipelines.gc_ingest tools db \
+  --db-backup-base-prefix "gamechanger/backup/db/" \
+  --bucket-name "advana_raw_zone" \
+  refresh \
+  --db "web"


### PR DESCRIPTION
PROBLEM: 
The json_metadata field in versioned_docs and gc_document_corpus_snapshot were text types not json types

SOLUTION:
- Fixed ingest statement to ingest json type (json.dump(j) -> j in models)
- Created script to fix the issue with the rest of the data currently in postgres (see dataPipelines/scripts/fix_json_metadata.sh)
-Fixed revoker to handle jsons instead of text types

TODO: 
Run dataPipelines/scripts/fix_json_metadata.sh before next data deploy