### PR TITLE
Task/uot 122338 - cleaning up rank features

### DIFF
--- a/common/document_parser/lib/keywords.py
+++ b/common/document_parser/lib/keywords.py
@@ -11,8 +11,3 @@ def add_keyw_5(doc_dict):
     kw_list.sort(reverse=True)
     doc_dict["keyw_5"] = [x[1] for x in kw_list[:10]]
     return doc_dict
-
-
-def add_kw_doc_score_r(doc_dict):
-    doc_dict["kw_doc_score_r"] = get_kw_score(doc_dict["id"])
-    return doc_dict

--- a/common/document_parser/lib/keywords.py
+++ b/common/document_parser/lib/keywords.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from gamechangerml.src.featurization.rank_features.features import get_kw_score
 
 
 def add_keyw_5(doc_dict):

--- a/common/document_parser/lib/keywords.py
+++ b/common/document_parser/lib/keywords.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from gamechangerml.src.search.ranking.features import get_kw_score
+from gamechangerml.src.featurization.rank_features.features import get_kw_score
 
 
 def add_keyw_5(doc_dict):

--- a/common/document_parser/lib/ml_features.py
+++ b/common/document_parser/lib/ml_features.py
@@ -1,26 +1,9 @@
-from gamechangerml.src.search.ranking import features as ft
-
+from gamechangerml.src.featurization.rank_features import features as ft
 
 def add_pagerank_r(doc_dict):
     doc_dict["pagerank_r"] = ft.get_pr(doc_dict["id"])
     return doc_dict
 
-
 def add_popscore_r(doc_dict):
     doc_dict["pop_score"] = ft.get_pop_score(doc_dict["filename"])
-    return doc_dict
-
-
-def add_orgs_rs(doc_dict):
-    doc_dict["orgs_rs"] = ft.get_orgs(doc_dict["id"])
-    return doc_dict
-
-
-def add_kw_doc_score_r(doc_dict):
-    doc_dict["kw_doc_score_r"] = ft.get_kw_score(doc_dict["id"])
-    return doc_dict
-
-
-def add_txt_length(doc_dict):
-    doc_dict["txt_length"] = ft.get_txt_length(doc_dict["id"])
     return doc_dict

--- a/common/document_parser/lib/organizations.py
+++ b/common/document_parser/lib/organizations.py
@@ -1,6 +1,0 @@
-from gamechangerml.src.featurization.rank_features.features import get_orgs
-
-
-def add_orgs_rs(doc_dict):
-    doc_dict["orgs_rs"] = get_orgs(doc_dict["id"])
-    return doc_dict

--- a/common/document_parser/lib/organizations.py
+++ b/common/document_parser/lib/organizations.py
@@ -1,4 +1,4 @@
-from gamechangerml.src.search.ranking.features import get_orgs
+from gamechangerml.src.featurization.rank_features.features import get_orgs
 
 
 def add_orgs_rs(doc_dict):

--- a/common/document_parser/lib/page_rank.py
+++ b/common/document_parser/lib/page_rank.py
@@ -1,4 +1,4 @@
-from gamechangerml.src.search.ranking.features import get_pr
+from gamechangerml.src.featurization.rank_features.features import get_pr
 
 
 def add_pagerank_r(doc_dict):

--- a/common/document_parser/lib/text_length.py
+++ b/common/document_parser/lib/text_length.py
@@ -1,5 +1,3 @@
-from gamechangerml.src.featurization.rank_features.features import get_txt_length
-
 def add_word_count(doc_dict):
     doc_dict["word_count"] = len(doc_dict["text"].split(" "))
     return doc_dict

--- a/common/document_parser/lib/text_length.py
+++ b/common/document_parser/lib/text_length.py
@@ -1,4 +1,4 @@
-from gamechangerml.src.search.ranking.features import get_txt_length
+from gamechangerml.src.featurization.rank_features.features import get_txt_length
 
 
 def add_txt_length(doc_dict):

--- a/common/document_parser/lib/text_length.py
+++ b/common/document_parser/lib/text_length.py
@@ -1,11 +1,5 @@
 from gamechangerml.src.featurization.rank_features.features import get_txt_length
 
-
-def add_txt_length(doc_dict):
-    doc_dict["txt_length"] = get_txt_length(doc_dict["id"])
-    return doc_dict
-
-
 def add_word_count(doc_dict):
     doc_dict["word_count"] = len(doc_dict["text"].split(" "))
     return doc_dict

--- a/common/document_parser/parsers/policy_analytics/parse.py
+++ b/common/document_parser/parsers/policy_analytics/parse.py
@@ -19,7 +19,7 @@ from common.document_parser.lib import (
 )
 from . import post_process, init_doc
 from common.document_parser.lib.ml_features import (
-    add_pagerank_r, add_popscore_r, add_orgs_rs, add_kw_doc_score_r, add_txt_length)
+    add_pagerank_r, add_popscore_r)
 
 
 def parse(
@@ -42,8 +42,8 @@ def parse(
     if str(f_name).endswith("html"):
         f_name = html_utils.get_html_filename(f_name)
         should_delete = True
-    funcs = [ref_list.add_ref_list, entities.extract_entities, topics.extract_topics, keywords.add_keyw_5, abbreviations.add_abbreviations_n, summary.add_summary, add_pagerank_r, add_popscore_r, add_orgs_rs,
-             add_kw_doc_score_r, add_txt_length, text_length.add_word_count]
+    funcs = [ref_list.add_ref_list, entities.extract_entities, topics.extract_topics, keywords.add_keyw_5, abbreviations.add_abbreviations_n, summary.add_summary, add_pagerank_r, add_popscore_r, 
+             text_length.add_word_count]
     try:
         doc_obj = pdf_reader.get_fitz_doc_obj(f_name)
         pages.handle_pages(doc_obj, doc_dict)

--- a/common/document_parser/parsers/policy_analytics/parse.py
+++ b/common/document_parser/parsers/policy_analytics/parse.py
@@ -7,8 +7,6 @@ from common.document_parser.lib import (
     ref_list,
     abbreviations,
     summary,
-    page_rank,
-    organizations,
     keywords,
     text_length,
     read_meta,


### PR DESCRIPTION
Changes:
- changed filepaths to new data organization in gamechanger-ml
- removed unused rank feature functions

Testing:
- After re-installing gamechanger-ml, running pdf parser on directory of test pdfs worked:
```
python -m common.document_parser pdf-to-json -s "test_pdfs" -d "test_jsons"
python -m dataPipelines.gc_elasticsearch_publisher run -i "gamechanger_20211209_test" -d "test_jsons"
```
- Indexing JSONs in ES does not seem to mess up search (test index = `gamechanger_20211209_test`)