### PR TITLE
bugfix/uot-122605 SAMM and TFM HTML Parse Fix 

### DIFF
--- a/common/document_parser/lib/html_utils.py
+++ b/common/document_parser/lib/html_utils.py
@@ -1,18 +1,32 @@
-from common.utils.file_utils import is_pdf, is_ocr_pdf
-from .ocr import get_ocr_filename
+from typing import AnyStr, IO, Union
+from pathlib import Path
+
+import bs4
 from xhtml2pdf import pisa
 
-def get_html_filename(f_name) -> str:
-    """
-    creates pdf for parsing 
-    """
-    tmp_pdf = open(str(f_name).replace('.html', '.pdf'), "w+b")
-    if str(f_name).endswith("html"):
-        source_html = open(str(f_name), "r")
-        content = source_html.read()
-        source_html.close()
-        pisaStatus = pisa.CreatePDF(content, dest=tmp_pdf)
-        tmp_pdf.close()
+def clean_html_for_pdf(markup: Union[IO, AnyStr]) -> str:
+    """Cleans known issues from html that prevent pdf generation."""
+    soup = bs4.BeautifulSoup(markup, 'html5lib')
 
-    return str(f_name).replace('.html', '.pdf')
+    # remove any empty rows (i.e. <tr> tags without any child <td> or <th> tags)
+    rows = soup.find_all('tr')
+    for row in rows:
+        if row.find('td') is None and row.find('th') is None:
+            row.decompose()
 
+    return str(soup)
+
+def convert_html_to_pdf(filepath: Union[Path, str]) -> str:
+    """Creates pdf for parsing."""
+    filepath = Path(filepath)
+    if filepath.suffix == '.pdf':
+        return str(filepath)
+    with open(filepath, 'rb') as html_file:
+        html = clean_html_for_pdf(html_file)
+    pdf_path = filepath.with_suffix('.pdf')
+    with open(pdf_path, 'w+b') as pdf_file:
+        pisaStatus = pisa.CreatePDF(html, dest=pdf_file)
+    if pisaStatus.err:
+        raise RuntimeError(f'unable to generate pdf from {filepath}')
+
+    return str(pdf_path)

--- a/common/document_parser/lib/html_utils.py
+++ b/common/document_parser/lib/html_utils.py
@@ -46,7 +46,10 @@ def convert_html_to_pdf(filepath: Union[Path, str]) -> str:
         html = clean_html_for_pdf(html_file)
     pdf_path = filepath.with_suffix('.pdf')
     with open(pdf_path, 'w+b') as pdf_file:
-        pisaStatus = pisa.CreatePDF(html, dest=pdf_file)
+        try:
+            pisaStatus = pisa.CreatePDF(html, dest=pdf_file)
+        except Exception:
+            raise RuntimeError(f'unable to generate pdf from {filepath}')
     if pisaStatus.err:
         raise RuntimeError(f'unable to generate pdf from {filepath}')
 

--- a/common/document_parser/lib/html_utils.py
+++ b/common/document_parser/lib/html_utils.py
@@ -6,6 +6,13 @@ from xhtml2pdf import pisa
 from xhtml2pdf.context import pisaCSSBuilder
 from xhtml2pdf.w3c.cssParser import CSSParser
 
+def _remove_empty_attr(soup: bs4.BeautifulSoup, attr: str) -> None:
+    """Removes the specified attribute from all tags if empty."""
+    tags = soup.find_all(attrs={attr: True})
+    for tag in tags:
+        if tag[attr] == '':
+            del tag[attr]
+
 def clean_html_for_pdf(markup: Union[IO, AnyStr]) -> str:
     """Cleans known issues from html that prevent pdf generation."""
     soup = bs4.BeautifulSoup(markup, 'html5lib')
@@ -23,6 +30,10 @@ def clean_html_for_pdf(markup: Union[IO, AnyStr]) -> str:
         parsed_style = css_parser.parseInline(tag['style'])[0]
         if any(value is NotImplemented for value in parsed_style.values()):
             del tag['style']
+
+    # remove problematic empty attributes
+    _remove_empty_attr(soup, 'colspan')
+    _remove_empty_attr(soup, 'rowspan')
 
     return str(soup)
 

--- a/common/document_parser/lib/html_utils.py
+++ b/common/document_parser/lib/html_utils.py
@@ -4,7 +4,17 @@ from pathlib import Path
 import bs4
 from xhtml2pdf import pisa
 from xhtml2pdf.context import pisaCSSBuilder
+from xhtml2pdf.default import DEFAULT_CSS as XHTML2PDF_DEFAULT_CSS
 from xhtml2pdf.w3c.cssParser import CSSParser
+
+_DEFAULT_CSS = f'{XHTML2PDF_DEFAULT_CSS} table {{ -pdf-keep-in-frame-mode: shrink; }}'
+"""Default CSS to use when rendering html to pdf.
+
+Xhtml2pdf is unable to break table cells across pdf pages so will error if a cell is larger
+than a page. To work around this we shrink tables to fit within a page. This can result in 
+very small tables which are not suitable for human consumption but are fine for machine text
+extraction.
+"""
 
 def _remove_empty_rows(soup: bs4.BeautifulSoup) -> None:
     """Remove any empty rows (i.e. <tr> tags without any child <td> or <th> tags)."""
@@ -73,7 +83,7 @@ def convert_html_to_pdf(filepath: Union[Path, str]) -> str:
     pdf_path = filepath.with_suffix('.pdf')
     with open(pdf_path, 'w+b') as pdf_file:
         try:
-            pisaStatus = pisa.CreatePDF(html, dest=pdf_file)
+            pisaStatus = pisa.CreatePDF(html, dest=pdf_file, default_css=_DEFAULT_CSS)
         except Exception:
             raise RuntimeError(f'unable to generate pdf from {filepath}')
     if pisaStatus.err:

--- a/common/document_parser/parsers/policy_analytics/parse.py
+++ b/common/document_parser/parsers/policy_analytics/parse.py
@@ -40,7 +40,7 @@ def parse(
     if ocr_missing_doc or force_ocr:
         f_name = ocr.get_ocr_filename(f_name, num_ocr_threads, force_ocr)
     if str(f_name).endswith("html"):
-        f_name = html_utils.get_html_filename(f_name)
+        f_name = html_utils.convert_html_to_pdf(f_name)
         should_delete = True
     funcs = [ref_list.add_ref_list, entities.extract_entities, topics.extract_topics, keywords.add_keyw_5, abbreviations.add_abbreviations_n, summary.add_summary, add_pagerank_r, add_popscore_r, add_orgs_rs,
              add_kw_doc_score_r, add_txt_length, text_length.add_word_count]


### PR DESCRIPTION
Ingest failed for the SAMM and TFM data sources because the xhtml2pdf library threw errors while trying to convert some of the HTML to PDF (in some cases the HTML was technically malformed, in other cases xhtml2pdf simply didn't properly support the html construct). 

This PR adds a "cleaning" step that fixes known problematic HTML before passing it to xhtml2pdf. This includes:
- removing empty table rows
- removing unparseable style attributes
- removing some empty attributes
- capping overly large rowspan attributes

Default CSS was added that shrinks tables to fit on PDF pages (xhtml2pdf will error if a table cell is larger than a page).

Also, currently xhtml2pdf will attempt to hit the network or filesystem to load any links (e.g. images or stylesheets) which seems undesirable for our use case so I customized the link load function to replace images with a placeholder data URI and otherwise prevent the loading of any external links.

_For the future:_ While the above approach works for the current data sources, as we add new HTML documents we will likely have to continue to play whack-a-mole with the cleaning function as new problematic HTML crops up. Xhtml2pdf is not meant to be a general purpose HTML to CSS converter (it's intended to generate basic PDF reports from HTML that the developer controls). We may want to consider either developing an approach to extract the text directly from the HTML or switch to use a more powerful HTML to PDF library (unfortunately from my bit of research these all require some external dependencies and would require a rebuild of our container environments beyond just adding a new Python library).
