### PR TITLE
task/uot-127438 add logic to handle is_revoked field from scraped items

### DIFF
--- a/common/document_parser/parsers/eda_contract_search/post_process.py
+++ b/common/document_parser/parsers/eda_contract_search/post_process.py
@@ -103,6 +103,13 @@ def get_display_title(meta_data):
     doc_title = meta_data["doc_title"].strip()
     return doc_type + " " + doc_num + " " + doc_title
 
+def get_is_revoked(meta_data):
+    """
+    get revocation status from document metadata
+    :return: bool
+    """
+    return meta_data.get("is_revoked", False)
+
 
 def rename_and_format(doc_dict):
     doc_dict["raw_text"] = utf8_pass(doc_dict["text"])
@@ -117,8 +124,9 @@ def rename_and_format(doc_dict):
         doc_dict["data_source_s"] = get_data_source(doc_dict["meta_data"])
         doc_dict["source_title_s"] = get_source_title(doc_dict["meta_data"])
         doc_dict["display_source_s"] = get_display_source(doc_dict["meta_data"])
-
-    doc_dict["is_revoked_b"] = False
+        doc_dict["is_revoked_b"] = get_is_revoked(doc_dict["meta_data"])
+    else:
+        doc_dict["is_revoked_b"] = False
 
     to_rename = [
         ("txt_length", "text_length_r"),
@@ -134,7 +142,7 @@ def rename_and_format(doc_dict):
         try:
             doc_dict[needed] = doc_dict[current]
             del doc_dict[current]
-        except:
+        except KeyError:
             pass
 
     if doc_dict["meta_data"]:
@@ -161,7 +169,7 @@ def rename_and_format(doc_dict):
     for key in to_delete:
         try:
             del doc_dict[key]
-        except:
+        except KeyError:
             pass
 
     return doc_dict

--- a/common/document_parser/parsers/policy_analytics/post_process.py
+++ b/common/document_parser/parsers/policy_analytics/post_process.py
@@ -112,6 +112,13 @@ def get_file_extension(meta_data):
     file_ext = meta_data["downloadable_items"][0]["doc_type"]
     return file_ext
 
+def get_is_revoked(meta_data):
+    """
+    get revocation status from document metadata
+    :return: bool
+    """
+    return meta_data.get("is_revoked", False)
+
 
 def rename_and_format(doc_dict):
     doc_dict["raw_text"] = utf8_pass(doc_dict["text"])
@@ -128,8 +135,9 @@ def rename_and_format(doc_dict):
         doc_dict["data_source_s"] = get_data_source(doc_dict["meta_data"])
         doc_dict["source_title_s"] = get_source_title(doc_dict["meta_data"])
         doc_dict["display_source_s"] = get_display_source(doc_dict["meta_data"])
-
-    doc_dict["is_revoked_b"] = False
+        doc_dict["is_revoked_b"] = get_is_revoked(doc_dict["meta_data"])
+    else:
+        doc_dict["is_revoked_b"] = False
 
     to_rename = [
         ("txt_length", "text_length_r"),
@@ -145,7 +153,7 @@ def rename_and_format(doc_dict):
         try:
             doc_dict[needed] = doc_dict[current]
             del doc_dict[current]
-        except:
+        except KeyError:
             pass
 
     if doc_dict["meta_data"]:
@@ -172,7 +180,7 @@ def rename_and_format(doc_dict):
     for key in to_delete:
         try:
             del doc_dict[key]
-        except:
+        except KeyError:
             pass
 
     return doc_dict

--- a/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
+++ b/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
@@ -8,14 +8,14 @@ from dataPipelines.gc_neo4j_publisher.neo4j_publisher import process_query
 class CrawlerStatusTracker:
 
     def __init__(self, input_json):
-        self.input_json = input_json
-        self.input_doc_names = []
-        self.crawlers_downloaded = []
-        self.dbs_initiated = False
+        self._input_json = input_json
+        self._input_doc_names = []
+        self._crawlers_downloaded = []
+        self._dbs_initiated = False
 
-    def set_input_lists(self):
-        if Path(self.input_json).resolve():
-            input_json_path = Path(self.input_json).resolve()
+    def _set_input_lists(self):
+        if Path(self._input_json).resolve():
+            input_json_path = Path(self._input_json).resolve()
             with input_json_path.open(mode="r") as f:
                 for json_str in f.readlines():
                     if not json_str.strip():
@@ -26,28 +26,28 @@ class CrawlerStatusTracker:
                         except json.decoder.JSONDecodeError:
                             print("Encountered JSON decode error while parsing crawler output.")
                             continue
-                        self.input_doc_names.append(j_data["doc_name"])
-                        self.crawlers_downloaded.append(j_data["crawler_used"])
-                self.crawlers_downloaded = list(set(self.crawlers_downloaded))
+                        self._input_doc_names.append(j_data["doc_name"])
+                        self._crawlers_downloaded.append(j_data["crawler_used"])
+                self._crawlers_downloaded = list(set(self._crawlers_downloaded))
 
     def update_crawler_status(self, status: str, timestamp:dt.timestamp, update_db:bool):
-        if not self.dbs_initiated:
+        if not self._dbs_initiated:
             Config.connection_helper.init_dbs()
-            self.dbs_initiated = True
-        if not self.crawlers_downloaded:
-            self.set_input_lists()
+            self._dbs_initiated = True
+        if not self._crawlers_downloaded:
+            self._set_input_lists()
         formatted_timestamp = dt.strftime(timestamp, '%Y-%m-%dT%H:%M:%S')
 
         if update_db:
             with Config.connection_helper.orch_db_session_scope('rw') as session:
-                for crawler in self.crawlers_downloaded:
+                for crawler in self._crawlers_downloaded:
                     status_entry = CrawlerStatusEntry.create(status=status,
                                                              crawler_name=crawler,
                                                              datetime=formatted_timestamp)
                     session.add(status_entry)
                 session.commit()
 
-    def revoke_documents(self, update_db:bool):
+    def _revoke_documents(self, update_db:bool):
         with Config.connection_helper.orch_db_session_scope('rw') as session:
             db_revoked = session.query(Publication.name, VersionedDoc.json_metadata). \
                 join(VersionedDoc, Publication.name == VersionedDoc.name). \
@@ -68,14 +68,14 @@ class CrawlerStatusTracker:
                      if isinstance(j,str) else (name, j["crawler_used"])
                      for (name, j) in db_current]))
             for (doc, crawler) in db_current_list:
-                if doc not in self.input_doc_names and crawler in self.crawlers_downloaded and crawler != "legislation_pubs":
+                if doc not in self._input_doc_names and crawler in self._crawlers_downloaded and crawler != "legislation_pubs":
                     print("Publication " + doc + " is now revoked")
                     if update_db:
                         print("Updating DB to reflect " + doc + " is revoked")
                         pub = session.query(Publication).filter_by(name=doc).one()
                         pub.is_revoked = True
             for (doc, crawler) in db_revoked_list:
-                if doc in self.input_doc_names and crawler in self.crawlers_downloaded:
+                if doc in self._input_doc_names and crawler in self._crawlers_downloaded:
                     print("Publication " + doc + " is no longer revoked")
                     if update_db:
                         print("Updating DB to reflect " + doc + " is no longer revoked")
@@ -83,14 +83,14 @@ class CrawlerStatusTracker:
                         pub.is_revoked = False
             session.commit()
 
-    def get_revoked_documents(self):
+    def _get_revoked_documents(self):
         with Config.connection_helper.orch_db_session_scope('rw') as session:
             db_revoked = session.query(Publication.name).\
                 filter(Publication.is_revoked == True).all()
             db_revocations =list(set([name for (name,) in db_revoked]))
             return db_revocations
 
-    def get_non_revoked_documents(self):
+    def _get_non_revoked_documents(self):
         with Config.connection_helper.orch_db_session_scope('rw') as session:
             db_non_revoked = session.query(Publication.name).\
                 filter(Publication.is_revoked == False).all()
@@ -98,7 +98,7 @@ class CrawlerStatusTracker:
             return db_non_revocations
 
 # TODO fix "PDF" addition here. Add html
-    def update_revocations_es(self, doc_name_list, index_name:str):
+    def _update_revocations_es(self, doc_name_list, index_name:str):
 
         for doc in doc_name_list:
             print(
@@ -119,7 +119,7 @@ class CrawlerStatusTracker:
             }
             Config.connection_helper.es_client.update_by_query(index=index_name, body=update_body)
 
-    def update_revocations_neo4j(self, revoked_docs, non_revoked_docs):
+    def _update_revocations_neo4j(self, revoked_docs, non_revoked_docs):
         for doc in revoked_docs:
             process_query(
                 "MERGE (a:Document {name: \"" + doc + "\"}) SET a.is_revoked_b = true"
@@ -131,21 +131,19 @@ class CrawlerStatusTracker:
 
     def handle_revocations(self, index_name: str, update_es: bool, update_db: bool, update_neo4j: bool):
 
-        if not self.dbs_initiated:
+        if not self._dbs_initiated:
             Config.connection_helper.init_dbs()
-            self.dbs_initiated = True
-        if not self.crawlers_downloaded and self.input_json:
-            self.set_input_lists()
+            self._dbs_initiated = True
+        if not self._crawlers_downloaded and self._input_json:
+            self._set_input_lists()
 
-        if self.input_json and Path(self.input_json).resolve():
-            self.revoke_documents(update_db=update_db)
+        if self._input_json and Path(self._input_json).resolve():
+            self._revoke_documents(update_db=update_db)
 
-        docs_to_be_revoked = self.get_revoked_documents()
+        docs_to_be_revoked = self._get_revoked_documents()
         if update_es:
-            self.update_revocations_es(doc_name_list=docs_to_be_revoked, index_name=index_name)
+            self._update_revocations_es(doc_name_list=docs_to_be_revoked, index_name=index_name)
 
-        non_revoked_docs = self.get_non_revoked_documents()
+        non_revoked_docs = self._get_non_revoked_documents()
         if update_neo4j:
-            self.update_revocations_neo4j(revoked_docs=docs_to_be_revoked, non_revoked_docs=non_revoked_docs)
-
-
+            self._update_revocations_neo4j(revoked_docs=docs_to_be_revoked, non_revoked_docs=non_revoked_docs)

--- a/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
+++ b/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
@@ -17,7 +17,6 @@ class CrawlerStatusTracker:
     def __init__(self, input_json: Union[str, os.PathLike]):
         self._input_json = input_json
         self._input_doc_names = set()
-        self._input_docs_revoked_by_crawler = set()
         self._crawlers_downloaded = set()
         self._dbs_initiated = False
 
@@ -35,8 +34,6 @@ class CrawlerStatusTracker:
                         continue
                     self._input_doc_names.add(j_data["doc_name"])
                     self._crawlers_downloaded.add(j_data["crawler_used"])
-                    if j_data.get("is_revoked", False):
-                        self._input_docs_revoked_by_crawler.add(j_data["doc_name"])
                     
     def update_crawler_status(self, status: str, timestamp:dt.timestamp, update_db:bool):
         if not self._dbs_initiated:
@@ -106,8 +103,10 @@ class CrawlerStatusTracker:
                 if crawler_used not in self._crawlers_downloaded:
                     continue
 
+                meta_is_revoked = doc_json_metadata.get('is_revoked', False)
+
                 # doc is considered revoked if marked as such by the crawler ...
-                if doc_name in self._input_docs_revoked_by_crawler:
+                if meta_is_revoked:
                     updated_is_revoked = True
                 else:  # ... otherwise doc is considered revoked if missing from the new input document set
                     updated_is_revoked = doc_name not in self._input_doc_names

--- a/dataPipelines/gc_db_utils/orch/models.py
+++ b/dataPipelines/gc_db_utils/orch/models.py
@@ -38,7 +38,7 @@ class Publication(AutoRepr, PublicationSchema, DeferredOrchReflectedBase):
             type=doc['doc_type'],
             number=doc['doc_num'],
             is_ignored=False,
-            is_revoked=False
+            is_revoked=doc.get('is_revoked', False)
         )
 
     @staticmethod


### PR DESCRIPTION
This PR adds logic that allows documents to be ingested as revoked if the crawler marks the doc item as `is_revoked`. If this field is marked true by the crawler then it overrides the default behavior that always marks a document as _not_ revoked if it appears in the list of documents to ingest.

Depends on https://github.com/dod-advana/gamechanger-crawlers/pull/76 
