### PR TITLE
bugfix/UOT-129178 fix issue with pdfdoc text codec preventing HTML > PDF conversion

### DIFF
--- a/dev_tools/requirements/gc-venv-current.txt
+++ b/dev_tools/requirements/gc-venv-current.txt
@@ -137,7 +137,7 @@ pansi==2020.7.3
 parsel==1.6.0
 pathy==0.5.2
 pdfminer.six==20201018
-pikepdf==2.0.0
+pikepdf==2.16.1
 Pillow==8.0.1
 plac==1.1.3
 pluggy==0.13.1

--- a/dev_tools/requirements/rhel8.locked.requirements.txt
+++ b/dev_tools/requirements/rhel8.locked.requirements.txt
@@ -79,7 +79,7 @@ packaging==21.0
 pandas==1.3.4
 pathy==0.6.0
 pdfminer.six==20201018
-pikepdf==3.2.0
+pikepdf==2.16.1
 Pillow==8.4.0
 pluggy==1.0.0
 preshed==3.0.5


### PR DESCRIPTION
The 'pdfdoc' codec in the version of the `pikepdf` library we use doesn't raise encoding errors in the expected way (raising `UnicodeEncodeError`) which breaks other code used in our HTML to PDF conversion. Bumping the version to 2.16.1 fixes the issue and allows the conversion to proceed.

see: https://github.com/pikepdf/pikepdf/issues/218