### PR TITLE
task/uot-127438 fix logic to handle is_revoked field

### DIFF
--- a/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
+++ b/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
@@ -136,8 +136,19 @@ class CrawlerStatusTracker:
         for doc in docs:
             update_body = {
                 "query": {
-                    "term": {
-                        "filename": doc.filename
+                    "bool": {
+                        "must": [
+                            {
+                                "term": {
+                                    "filename": doc.filename
+                                }
+                            },
+                            {
+                                "term": {
+                                    "crawler_used_s": doc.json_metadata['crawler_used']
+                                }
+                            }
+                        ]
                     }
                 },
                 "script": {

--- a/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
+++ b/dataPipelines/gc_crawler_status_tracker/gc_crawler_status_tracker.py
@@ -165,8 +165,11 @@ class CrawlerStatusTracker:
         print(f'Updating Neo4j revocation statuses')
         for doc in docs:
             process_query(
-                f'MERGE (a:Document {{ name: "{doc.name}" }}) '
-                f'SET a.is_revoked_b = {"true" if doc.is_revoked else "false"}'
+                'MATCH (a:Document { name: $name, crawler_used_s: $crawler_used })'
+                'SET a.is_revoked_b = $is_revoked',
+                name=doc.name,
+                crawler_used=doc.json_metadata['crawler_used'],
+                is_revoked=doc.is_revoked,
             )
 
     def handle_revocations(self, index_name: str, update_es: bool, update_db: bool, update_neo4j: bool):

--- a/dataPipelines/gc_neo4j_publisher/neo4j_publisher.py
+++ b/dataPipelines/gc_neo4j_publisher/neo4j_publisher.py
@@ -54,12 +54,12 @@ def process_ent(ent: str) -> t.Union[t.List[str], str]:
         return ent
 
 
-def process_query(query: str) -> None:
+def process_query(query: str, parameters: t.Dict[str, t.Any] = None, **kwparameters) -> None:
     with MainConfig.connection_helper.neo4j_session_scope() as session:
         try_count = 0
         while try_count <= 10:
             try:
-                result = session.run(query)
+                result = session.run(query, parameters, **kwparameters)
                 return
             except exceptions.TransientError:
                 try_count += 1


### PR DESCRIPTION
Adds logic to also check crawler used when updating Elasticsearch and Neo4j.

Also removes a broken optimization and moves conditional json parse of improperly json encoded strings server side.