### PR TITLE
task/uot-130512 add support for txt files

### DIFF
--- a/common/document_parser/lib/file_utils.py
+++ b/common/document_parser/lib/file_utils.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Union
+
+from common.document_parser.lib.html_utils import convert_html_file_to_pdf, convert_html_to_pdf, convert_text_to_html
+from common.document_parser.lib.reading_in import read_plain_text
+
+
+def coerce_file_to_pdf(filepath: Union[Path, str]) -> str:
+    """Attempts to convert the given file to a pdf and returns the pdf filepath."""
+    filepath = Path(filepath)
+    filetype = filepath.suffix
+    if filetype == '.pdf':
+        return str(filepath)
+    elif filetype == '.html':
+        return convert_html_file_to_pdf(filepath)
+    elif filetype == '.txt':
+        text = read_plain_text(filepath)
+        html = convert_text_to_html(text)
+        return convert_html_to_pdf(filepath, html)
+    else:
+        raise ValueError(f'unsupported filetype {filetype}')

--- a/common/document_parser/lib/html_utils.py
+++ b/common/document_parser/lib/html_utils.py
@@ -91,13 +91,9 @@ def clean_html_for_pdf(markup: Union[IO, AnyStr]) -> str:
 
     return str(soup)
 
-def convert_html_to_pdf(filepath: Union[Path, str]) -> str:
-    """Creates pdf for parsing."""
+def convert_html_to_pdf(filepath: Union[Path, str], html: str) -> str:
+    """Creates pdf file for parsing from an html string."""
     filepath = Path(filepath)
-    if filepath.suffix == '.pdf':
-        return str(filepath)
-    with open(filepath, 'rb') as html_file:
-        html = clean_html_for_pdf(html_file)
     pdf_path = filepath.with_suffix('.pdf')
     with open(pdf_path, 'w+b') as pdf_file:
         try:
@@ -106,5 +102,24 @@ def convert_html_to_pdf(filepath: Union[Path, str]) -> str:
             raise RuntimeError(f'unable to generate pdf from {filepath}')
     if pisaStatus.err:
         raise RuntimeError(f'unable to generate pdf from {filepath}')
-
     return str(pdf_path)
+    
+def convert_html_file_to_pdf(filepath: Union[Path, str]) -> str:
+    """Creates pdf file for parsing from an html file."""
+    with open(filepath, 'rb') as html_file:
+        html = clean_html_for_pdf(html_file)
+    return convert_html_to_pdf(filepath, html)
+
+def convert_text_to_html(text: str) -> str:
+    """Returns equivalent html containing the provided text."""
+    lines = text.splitlines()
+
+    soup = bs4.BeautifulSoup('<html><body></body></html>', 'html5lib')
+    body = soup.body
+    for line in lines:
+        body.append(line)
+        br = soup.new_tag('br')
+        body.append(br)
+
+    html = str(soup)
+    return html

--- a/common/document_parser/lib/paragraphs.py
+++ b/common/document_parser/lib/paragraphs.py
@@ -1,19 +1,25 @@
-import syntok.segmenter as segmenter
-
 import re
-import string
-from gamechangerml.src.utilities.text_utils import utf8_pass, clean_text
+from typing import Iterable, List
+
+import syntok.segmenter as segmenter
+import syntok.tokenizer as tokenizer
+from gamechangerml.src.utilities.text_utils import utf8_pass
 
 
-def get_paragraph_text(segmented):
-    par_text = ""
-
+def get_paragraph_text(segmented: Iterable[List[tokenizer.Token]]) -> str:
+    sentences = []
     for sentence in segmented:
-        sentence_text = "".join(
+        sentence_text = ''.join(
             [token.spacing + token.value for token in sentence]
         )
-        par_text += sentence_text.replace('\n', '')
-
+        # substitute newlines that do not have whitespace before or after with a space
+        sentence_text = re.sub(r'(?<=\S)\n(?=\S)', ' ', sentence_text)
+        # strip any remaining newlines
+        sentence_text = sentence_text.replace('\n', '')
+        # clean any extra whitespace at the beginning or end
+        sentence_text = sentence_text.strip()
+        sentences.append(sentence_text)
+    par_text = ' '.join(sentences)
     return par_text
 
 

--- a/common/document_parser/lib/reading_in.py
+++ b/common/document_parser/lib/reading_in.py
@@ -12,6 +12,7 @@ from common.document_parser.ref_utils import make_dict
 from collections import defaultdict
 from typing import Pattern, List
 import typing as t
+import chardet
 
 ref_regex = make_dict()
 
@@ -34,7 +35,7 @@ def read_doc_dict(fname: Path) -> defaultdict:
 
 def read_plain_text(fname: Path) -> str:
     """
-    Reading Plain text file
+    Reading Plain text file. Attempts to guess the correct encoding, else falls back to latin1.
 
     Args:
         fname: name of text file
@@ -42,7 +43,7 @@ def read_plain_text(fname: Path) -> str:
     Returns:
         text string from file
     """
-    with open(fname) as f_in:
-        text = f_in.read()
-
-    return text
+    with open(fname, 'rb') as f_in:
+        text_bytes = f_in.read()
+    encoding = chardet.detect(text_bytes)['encoding'] or 'latin1'
+    return text_bytes.decode(encoding)

--- a/common/document_parser/parsers/policy_analytics/parse.py
+++ b/common/document_parser/parsers/policy_analytics/parse.py
@@ -13,7 +13,7 @@ from common.document_parser.lib import (
     pdf_reader,
     write_doc_dict_to_json,
     ocr,
-    html_utils,
+    file_utils,
 )
 from . import post_process, init_doc
 from common.document_parser.lib.ml_features import (
@@ -37,8 +37,8 @@ def parse(
     should_delete = False
     if ocr_missing_doc or force_ocr:
         f_name = ocr.get_ocr_filename(f_name, num_ocr_threads, force_ocr)
-    if str(f_name).endswith("html"):
-        f_name = html_utils.convert_html_to_pdf(f_name)
+    if not str(f_name).endswith(".pdf"):
+        f_name = file_utils.coerce_file_to_pdf(f_name)
         should_delete = True
     funcs = [ref_list.add_ref_list, entities.extract_entities, topics.extract_topics, keywords.add_keyw_5, abbreviations.add_abbreviations_n, summary.add_summary, add_pagerank_r, add_popscore_r, 
              text_length.add_word_count]

--- a/common/document_parser/process.py
+++ b/common/document_parser/process.py
@@ -157,7 +157,7 @@ def process_dir(
     """
 
     p = Path(dir_path).glob("**/*")
-    files = [x for x in p if x.is_file() and (str(x).endswith("pdf") or str(x).endswith("html")
+    files = [x for x in p if x.is_file() and (x.suffix.lower() in (".pdf", ".html", ".txt")
         or (filetype.guess(str(x)) is not None and (filetype.guess(str(x)).mime == "pdf" or filetype.guess(str(x)).mime == "application/pdf")))]
     data_inputs = [(parse_func, f_name, str(f_name)+'.metadata', ocr_missing_doc,
                     num_ocr_threads, force_ocr, out_dir) for f_name in files]

--- a/dataPipelines/gc_ingest/tools/load/utils.py
+++ b/dataPipelines/gc_ingest/tools/load/utils.py
@@ -57,7 +57,7 @@ class IngestableDocGroup(BaseModel):
 
 
 class LoadManager:
-    SUPPORTED_RAW_DOC_EXTENSIONS = frozenset({'.pdf', '.html'})
+    SUPPORTED_RAW_DOC_EXTENSIONS = frozenset({'.pdf', '.html', '.txt'})
     METADATA_DOC_EXTENSION = '.metadata'
     PARSED_DOC_EXTENSION = '.json'
     THUMBNAIL_EXTENSION = '.png'

--- a/dataPipelines/gc_manual_metadata/gc_manual_metadata.py
+++ b/dataPipelines/gc_manual_metadata/gc_manual_metadata.py
@@ -33,7 +33,7 @@ class ManualMetadata:
         self.input_directory = input_directory
         self.document_group = document_group
         p = Path(self.input_directory).glob("**/*")
-        self.files = [x for x in p if x.is_file() and (str(x).endswith("pdf") or str(x).endswith("html")
+        self.files = [x for x in p if x.is_file() and (x.suffix.lower() in (".pdf", ".html", ".txt")
                                                        or (filetype.guess(str(x)) is not None and (
                                                            filetype.guess(str(x)).mime == "pdf" or filetype.guess(str(x)).mime == "application/pdf")))]
         self.metadata_files = [Path(x).stem for x in p if x.is_file() and filetype.guess(str(x)) is not None and (

--- a/dataPipelines/scripts/matching.py
+++ b/dataPipelines/scripts/matching.py
@@ -13,7 +13,10 @@ output_base_dir.mkdir(exist_ok=True)
 output_unparsed.mkdir(exist_ok=True)
 output_raw.mkdir(exist_ok=True)
 output_parsed.mkdir(exist_ok=True)
-raw_docs = [x for x in raw_docs_dir.iterdir() if x.name.lower().endswith("pdf") or x.name.lower().endswith("html")]
+raw_docs = [x for x in raw_docs_dir.iterdir() if x.name.lower().endswith("pdf")
+            or x.name.lower().endswith("html")
+            or x.name.lower().endswith("txt")
+            ]
 crawler_output_file = Path(raw_docs_dir, "crawler_output.json")
 
 for raw_file in raw_docs:


### PR DESCRIPTION
This PR adds ingest support for plaintext files.

In order to reduce the number of code paths this is accomplished by converting the text to PDF and then using the preexisting pipeline.