### PR TITLE
fix paths for agencies path/abbcount path for neo4j updates

### DIFF
--- a/dataPipelines/gc_neo4j_publisher/config.py
+++ b/dataPipelines/gc_neo4j_publisher/config.py
@@ -6,8 +6,8 @@ from functools import lru_cache
 
 class Config:
     connection_helper = get_connection_helper_from_env()
-    abbcount_json_path = os.path.join(PACKAGE_PATH, "src/featurization/data/abbcounts.json")
-    agencies_csv_path = os.path.join(PACKAGE_PATH, "data/agencies/agencies.csv")
+    abbcount_json_path = os.path.join(PACKAGE_PATH, "data/features/abbcounts.json")
+    agencies_csv_path = os.path.join(PACKAGE_PATH, "data/features/agencies.csv")
 
     @classmethod
     @lru_cache(maxsize=None)


### PR DESCRIPTION
Paths were out of date to find the appropriate files in gamechanger-ml. these paths are now updated