### PR TITLE
Task/uot 132229 - adding Neo4j cluster algos to graph

### DIFF
--- a/dataPipelines/gc_neo4j_publisher/utils.py
+++ b/dataPipelines/gc_neo4j_publisher/utils.py
@@ -163,44 +163,51 @@ class Neo4jJobManager:
 
                 # Create Similarity Links
                 print("Creating node2vec properties ... ", file=sys.stderr)
-                session.run(
-                    "CALL gds.alpha.node2vec.write( " +
-                    "   { " +
-                    "       nodeProjection: ['Document', 'Entity', 'Topic', 'UKN_Document'], " +
-                    "       relationshipProjection: ['REFERENCES', 'REFERENCES_UKN', 'CHILD_OF', 'RELATED_TO', 'CONTAINS', 'MENTIONS', 'IS_IN'], " +
-                    "       relationshipProperties: ['count', 'relevancy'], " +
-                    "       embeddingDimension: 64, " +
-                    "       walkLength: 10, " +
-                    "       iterations: 3, " +
-                    "       writeProperty: 'nodeVec' " +
-                    "   } " +
-                    ");"
-                )
+                try:
+                    session.run(
+                        "CALL gds.alpha.node2vec.write( " +
+                        "   { " +
+                        "       nodeProjection: ['Document', 'Entity', 'Topic', 'UKN_Document'], " +
+                        "       relationshipProjection: ['REFERENCES', 'REFERENCES_UKN', 'CHILD_OF', 'RELATED_TO', 'CONTAINS', 'MENTIONS', 'IS_IN'], " +
+                        "       relationshipProperties: ['count', 'relevancy'], " +
+                        "       embeddingDimension: 64, " +
+                        "       walkLength: 10, " +
+                        "       iterations: 3, " +
+                        "       writeProperty: 'nodeVec' " +
+                        "   } " +
+                        ");"
+                    )
+                except Exception as e:
+                    print(f"Error: {e}")
 
                 print("Creating similarity relationships ... ", file=sys.stderr)
-                session.run(
-                    "MATCH (d:Document) " +
-                    "WITH {item:id(d), weights: d.nodeVec} AS docData " +
-                    "WITH collect(docData) AS data " +
-                    "CALL gds.alpha.similarity.cosine.stream({ " +
-                    "  data: data, " +
-                    "  similarityCutoff: 0.5 " +
-                    "}) " +
-                    "YIELD item1, item2, similarity " +
-                    "WITH gds.util.asNode(item1) AS NODE1, gds.util.asNode(item2) AS NODE2, similarity " +
-                    "MERGE (NODE1)-[:SIMILAR_TO {similarity: similarity}]->(NODE2);"
-                )
+                try:
+                    session.run(
+                        "MATCH (d:Document) " +
+                        "WITH {item:id(d), weights: d.nodeVec} AS docData " +
+                        "WITH collect(docData) AS data " +
+                        "CALL gds.alpha.similarity.cosine.stream({ " +
+                        "  data: data, " +
+                        "  similarityCutoff: 0.5 " +
+                        "}) " +
+                        "YIELD item1, item2, similarity " +
+                        "WITH gds.util.asNode(item1) AS NODE1, gds.util.asNode(item2) AS NODE2, similarity " +
+                        "MERGE (NODE1)-[:SIMILAR_TO {similarity: similarity}]->(NODE2);"
+                    )
+                except Exception as e:
+                    print(f"Error: {e}")
                 
                 # create graph
                 print("Creating graph for making clusters ... ", file=sys.stderr)
                 try:
                     session.run(
-                        "CALL gds.graph.create.cypher('recGraph'," +
-                        "MATCH (n) WHERE n:Document OR n:Entity OR n:Topic OR n:Responsibility" +
-                        "RETURN id(n) AS id, labels(n) AS labels'," +
-                        "MATCH (n)-[r:REFERENCES|MENTIONS|IS_IN|CONTAINS|CHILD_OF]->(m)" +
-                        "RETURN id(n) AS source, id(m) AS target, type(r) AS type')" +
-                        "YIELD" +
+                        "CALL gds.graph.create.cypher( " +
+                            "'recGraph', " +
+                            "'MATCH (n) WHERE n:Document OR n:Entity OR n:Topic OR n:Responsibility " +
+                            "RETURN id(n) AS id, labels(n) AS labels', " +
+                            "'MATCH (n)-[r:REFERENCES|MENTIONS|IS_IN|CONTAINS|CHILD_OF]->(m) " +
+                            "RETURN id(n) AS source, id(m) AS target, type(r) AS type') " +
+                        "YIELD " +
                         "graphName AS graph, nodeQuery, nodeCount AS nodes, relationshipCount AS rels"
                     )
                 except Exception as e:
@@ -210,7 +217,7 @@ class Neo4jJobManager:
                 print("Creating and writing Louvain cluster assignments ... ", file=sys.stderr)
                 try:
                     session.run(
-                        "CALL gds.louvain.write('recGraph', { writeProperty: 'louvain_community' })" + 
+                        "CALL gds.louvain.write('recGraph', { writeProperty: 'louvain_community' }) " + 
                         "YIELD communityCount, modularity, modularities"
                     )
                 except Exception as e:
@@ -220,7 +227,7 @@ class Neo4jJobManager:
                 print("Creating and writing label propagation cluster assignments ... ", file=sys.stderr)
                 try:
                     session.run(
-                        "CALL gds.labelPropagation.write('recGraph', { writeProperty: 'lp_community' })" +
+                        "CALL gds.labelPropagation.write('recGraph', { writeProperty: 'lp_community' }) " +
                         "YIELD communityCount, ranIterations, didConverge"
                     )
                 except Exception as e:
@@ -229,9 +236,18 @@ class Neo4jJobManager:
                 print("Getting and writing betweenness scores ... ", file=sys.stderr)
                 try:
                     session.run(
-                        "CALL gds.betweenness.write('recGraph', { writeProperty: 'betweenness' })" +
-                        "YIELD centralityDistribution, nodePropertiesWritten" +
+                        "CALL gds.betweenness.write('recGraph', { writeProperty: 'betweenness' }) " +
+                        "YIELD centralityDistribution, nodePropertiesWritten " +
                         "RETURN centralityDistribution.min AS minimumScore, centralityDistribution.mean AS meanScore, nodePropertiesWritten"
+                    )
+                except Exception as e:
+                    print(f"Error: {e}")
+                
+                # delete graph if exists
+                print("Deleting recGraph")
+                try:
+                    session.run(
+                        "CALL gds.graph.drop('recGraph')"
                     )
                 except Exception as e:
                     print(f"Error: {e}")


### PR DESCRIPTION
## Description
Creates and writes three properties for nodes in Neo4j graph: Louvain community, Label Propagation community, and betweenness score. After writing the properties to nodes, tears down the temporary graph created to calculate the values.  [UOT-132229](https://jira.di2e.net/secure/RapidBoard.jspa?rapidView=19041&view=detail&selectedIssue=UOT-132229)

## Testing
To test locally against a test directory of a subset of the corpus (TEST_CORPUS_DIR):
1. Start a local Neo4j DB locally (needs to have the Gamechanger plugins, gds and apoc plugins).
2. Run these commands:
```python -m configuration init local```
```python -m dataPipelines.gc_neo4j_publisher run -s TEST_CORPUS_DIR```

## Test Output:
```(gc36) katherinedowdy@FVFYM0L5HV2G gamechanger-data % python -m dataPipelines.gc_neo4j_publisher run -s corpus_sample
Could not retrieve gc_assists table - it doesn't exist.
Inserting 464 entities ...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 549/549 [13:13<00:00,  1.41s/it]Inserting 0 entities...
Creating UKN Documents, REFERENCES, and REFERENCES_UKN links...
Creating node2vec properties ... 
Error: {code: Neo.ClientError.Procedure.ProcedureNotFound} {message: There is no procedure with the name `gds.alpha.node2vec.write` registered for this database instance. Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.}
Creating similarity relationships ... 
Creating graph for making clusters ... 
Creating and writing Louvain cluster assignments ... 
Creating and writing label propagation cluster assignments ... 
Getting and writing betweenness scores ... 
Deleting recGraph
Done
```
** I think my version of Neo4j has a different version of the node2vec algo (from the existing code) which is why my test output is giving an error for that step. 