### PR TITLE
remove the alias ilm-history-3 which elasticsearch tries to purge

### DIFF
--- a/dev_tools/universal_test_harness/tools/es.py
+++ b/dev_tools/universal_test_harness/tools/es.py
@@ -37,7 +37,8 @@ def purge(purge_choice: str):
 
     def purge_aliases():
         print("Purging aliases ::")
-        for alias in [a for a in aliases if not any([pattern in a for pattern in exclude_patterns])]:
+        for alias in [a for a in aliases if (not any([pattern in a for pattern in exclude_patterns])
+                                             and not a == 'ilm-history-3')]:
             print(f'Deleting alias :: {alias}')
             es.indices.delete_alias(index='_all', name=alias)
 


### PR DESCRIPTION
During setup, elasticsearch tries to remove an alias it shouldn't. this checks for that alias