### PR TITLE
UOT-148294

### DIFF
--- a/common/document_parser/lib/entities_utils.py
+++ b/common/document_parser/lib/entities_utils.py
@@ -2,7 +2,7 @@ import pandas as pd
 import re
 
 def replace_nonalpha_chars(text, replace_char=""):
-    return re.sub("[^a-zA-Z\s]+", replace_char, text)
+    return re.sub("[^a-zA-Z0-9\s]+", replace_char, text)
 
 def make_entities_dict(
         entities_path,


### PR DESCRIPTION
JIRA Ticket: https://jira.di2e.net/browse/UOT-148294

Description: Prior to this update, the entity extraction logic scrubs all non alphabetical characters from the text/entities (including numbers), which is allowing entities such as `G-8` to match on any capital `G` that is found in the text, or `J7` to match on any capital `J` found in the text. This code update addresses this issue and ensure that entities are extracted properly by updating the regex to keep numbers intact to properly match some of these aliases which have numbers.

The pipeline has been run with this branch and is currently ingested on the `gamechanger` index in dev. To see results, navigate to our dev kibana https://vpc-gamechanger-dev-es-ms4wkfqyvlyt3gmiyak2hleqyu.us-east-1.es.amazonaws.com/_plugin/kibana/app/dev_tools#/console and see results there. e.g.
```
GET gamechanger/_search
{"size":100}
```