### PR TITLE
Improve parser efficiency: reference extraction

### DIFF
--- a/common/document_parser/lib/ref_list.py
+++ b/common/document_parser/lib/ref_list.py
@@ -52,7 +52,7 @@ def collect_ref_list(text: str) -> defaultdict:
         ref_dict with all references and their counts
     """
     ref_dict = defaultdict(int)
-    text = text.replace("\n", "")
+    text = " ".join(text.split())
     # allows regex to interpret the unicode as a -
     text = text.replace("\u2013", "-")
     text = re.sub(r"[()]", " ", text)

--- a/common/document_parser/lib/ref_list.py
+++ b/common/document_parser/lib/ref_list.py
@@ -1,15 +1,13 @@
 import re
-import json
-import argparse
-from pathlib import Path
-from common.document_parser.ref_utils import make_dict
 from collections import defaultdict
-from typing import Pattern, List
-import typing as t
+
+from common.document_parser.ref_utils import make_dict
+
+
 ref_regex = make_dict()
 
 
-def look_for_general(m_str: str, ref_dict: defaultdict, base_num: t.Pattern[str], full_num: t.Pattern[str], doc_type: str) -> defaultdict:
+def look_for_general(text, ref_dict, pattern, doc_type):
     """
     Reference Extraction by Regular Expression: For general use
 
@@ -23,21 +21,20 @@ def look_for_general(m_str: str, ref_dict: defaultdict, base_num: t.Pattern[str]
     Returns:
         updated ref_dict with the references found and their counts
     """
-    # Example for dodm
-    # base_num = re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)",re.IGNORECASE) # Example: 5025.01 or 5025.01
+    matches = pattern.findall(text)
 
-    # Example DODM
-    # dodm_full_num = re.compile(r"(((dod manual)|(dodm))\s*[0-9]{4}\.\s*[0-9]{1,3}(\s*,*\s*Volume\s*[0-9]+)?)",re.IGNORECASE) #Example: dod directive 5025.01, Volume 1 or  case insensitive
+    for match in matches:
+        if type(match) == tuple:
+            print(
+                f"ERR: Patterns in `ref_regex` should only have 1 capture "
+                f"group each. Check the pattern for {doc_type}"
+            )
+            continue
+        elif match == "":
+            continue
+        ref = (doc_type + " " + match).strip()
+        ref_dict[ref] += 1
 
-    directive = full_num.findall(m_str)
-
-    if directive is not None:
-        for match in directive:
-            num_match = base_num.search(match[0])
-            if not num_match:
-                continue
-            ref = (str(doc_type) + " " + str(num_match[0])).strip()
-            ref_dict[ref] += 1
     return ref_dict
 
 
@@ -52,15 +49,15 @@ def collect_ref_list(text: str) -> defaultdict:
         ref_dict with all references and their counts
     """
     ref_dict = defaultdict(int)
-    text = " ".join(text.split())
-    # allows regex to interpret the unicode as a -
+    # Interpret the unicode as a -
     text = text.replace("\u2013", "-")
     text = re.sub(r"[()]", " ", text)
+    # Normalize whitespace here so regex search is simpler
+    text = " ".join(text.split())
 
-    for key, value in ref_regex.items():
-        base = value[0]
-        full = value[1]
-        ref_dict = look_for_general(text, ref_dict, base, full, key)
+    for ref_type, pattern in ref_regex.items():
+        ref_dict = look_for_general(text, ref_dict, pattern, ref_type)
+
     return ref_dict
 
 

--- a/common/document_parser/ref_utils.py
+++ b/common/document_parser/ref_utils.py
@@ -3,353 +3,353 @@ import re
 def make_dict():
     ref_dict = {}
     ref_dict['DoD'] = (
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b(((dod\s*placeholder)|(dod))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
+        re.compile(r"\b(((dod ?placeholder)|(dod)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)",
         re.IGNORECASE)
     )
     ref_dict["DoDD"] = (
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b(((dod\s*directives?)|(dodd))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
+        re.compile(r"\b(((dod ?directives?)|(dodd)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)",
         re.IGNORECASE)
     )
     ref_dict["DoDI"] = (
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b(((dod\s*instruction)|(dodi))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
+        re.compile(r"\b(((dod ?instruction)|(dodi)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)",
         re.IGNORECASE)
     )
     ref_dict["DoDM"] = (
-        re.compile(r"([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}((\s*,*\s*Volume\s*[0-9]+)|(\s*(-\s*V[0-9])))?", re.IGNORECASE),
-        re.compile(r"\b(((dod\s*manual)|(dodm))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}((\s*,*\s*Volume\s*[0-9]+)|(\s*(-\s*V[0-9])))?)",
+        re.compile(r"([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}(( ?,* ?Volume ?[0-9]+)|( ?(- ?V[0-9])))?", re.IGNORECASE),
+        re.compile(r"\b(((dod ?manual)|(dodm)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}(( ?,* ?Volume ?[0-9]+)|( ?(- ?V[0-9])))?)",
         re.IGNORECASE)
     )
     ref_dict["DTM"] =(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b(((DTM)|(DT\s*Memorandum))\s*\)?\s*-?\s*[0-9]{2}\s*-\s*[0-9]{3})", re.IGNORECASE)
+        re.compile(r"[0-9]{2} ?- ?[0-9]{3}", re.IGNORECASE),
+        re.compile(r"\b(((DTM)|(DT ?Memorandum)) ?\)? ?-? ?[0-9]{2} ?- ?[0-9]{3})", re.IGNORECASE)
     )
     ref_dict["AI"] =(
         re.compile(r"([0-9]+)", re.IGNORECASE),
-        re.compile(r"\b(((administrative\s*instruction)|(ai))\s*\)?\s*[0-9]+)", re.IGNORECASE)
+        re.compile(r"\b(((administrative ?instruction)|(ai)) ?\)? ?[0-9]+)", re.IGNORECASE)
     )
     ref_dict["Title"] =(
         re.compile(r"([0-9]{1,2})", re.IGNORECASE),
-        re.compile(r"\b((Title)\s*[0-9]{1,2})", re.IGNORECASE)
+        re.compile(r"\b((Title) ?[0-9]{1,2})", re.IGNORECASE)
     )
     ref_dict["ICD"] =(
         re.compile(r"([0-9]{1,3})", re.IGNORECASE),
-        re.compile(r"\b(((Intelligence\s*Community\s*Directive)|(ICD))\s*\)?\s*[0-9]{1,3})", re.IGNORECASE)
+        re.compile(r"\b(((Intelligence ?Community ?Directive)|(ICD)) ?\)? ?[0-9]{1,3})", re.IGNORECASE)
     )
     ref_dict["ICPG"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{3}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b((icpg)\s*([A-Z]+-)?[0-9]{3}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE)
+        re.compile(r"(([A-Z]+-)?[0-9]{3}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
+        re.compile(r"\b((icpg) ?([A-Z]+-)?[0-9]{3}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE)
     )
     ref_dict["ICPM"] =(
-        re.compile(r"([0-9]{4}-\s*[0-9]{3}-\s*[0-9]{1})", re.IGNORECASE),
-        re.compile(r"\b((icpm)\s*[0-9]{4}-\s*[0-9]{3}-\s*[0-9]{1})", re.IGNORECASE)
+        re.compile(r"([0-9]{4}- ?[0-9]{3}- ?[0-9]{1})", re.IGNORECASE),
+        re.compile(r"\b((icpm) ?[0-9]{4}- ?[0-9]{3}- ?[0-9]{1})", re.IGNORECASE)
     )
     ref_dict["CJCSI"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs\s*instruction)|(cjcsi))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}([A-Z])?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
+        re.compile(r"\b(((cjcs ?instruction)|(cjcsi)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)",
         re.IGNORECASE)
     )
     ref_dict["CJCSM"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs\s*manual)|(cjcsm))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}([A-Z])?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
+        re.compile(r"\b(((cjcs ?manual)|(cjcsm)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)",
         re.IGNORECASE)
     )
     ref_dict["CJCSG"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\s*([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs\s*gde)|(cjcsg))\s*\)?\s*([A-Z]+-)?[0-9]{4}\s*([A-Z])?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4} ?([A-Z])?)", re.IGNORECASE),
+        re.compile(r"\b(((cjcs ?gde)|(cjcsg)) ?\)? ?([A-Z]+-)?[0-9]{4} ?([A-Z])?)",
         re.IGNORECASE)
     )
     ref_dict["CJCSN"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}(\.\s*[0-9]{0,3}([A-Z])?)?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs\s*notice)|(cjcsn))\s*\)?\s*([A-Z]+-)?[0-9]{4}(\.\s*[0-9]{0,3}([A-Z])?)?)",
+        re.compile(r"(([A-Z]+-)?[0-9]{4}(\. ?[0-9]{0,3}([A-Z])?)?)", re.IGNORECASE),
+        re.compile(r"\b(((cjcs ?notice)|(cjcsn)) ?\)? ?([A-Z]+-)?[0-9]{4}(\. ?[0-9]{0,3}([A-Z])?)?)",
         re.IGNORECASE)
     )
     ref_dict["JP"] =(
         re.compile(r"(([A-Z]+-)?[0-9]{1,2}-[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((joint\s*publication)|(jp))\s*\)?\s*([A-Z]+-)?[0-9]{1,2}-[0-9]{1,3}([A-Z])?)",
+        re.compile(r"\b(((joint ?publication)|(jp)) ?\)? ?([A-Z]+-)?[0-9]{1,2}-[0-9]{1,3}([A-Z])?)",
         re.IGNORECASE)
     )
     ref_dict["DCID"] =(
         re.compile(r"[0-9]\/[0-9]{1,2}(P)?", re.IGNORECASE),
-        re.compile(r"\b(((Director\s*of\s*Central\s*Intelligence\s*Directives)|(DCID))\s*\)?\s*[0-9]\/[0-9]{1,2}(P)?)",
+        re.compile(r"\b(((Director ?of ?Central ?Intelligence ?Directives)|(DCID)) ?\)? ?[0-9]\/[0-9]{1,2}(P)?)",
         re.IGNORECASE)
     )
     ref_dict["EO"] =(
         re.compile(r"[0-9]{5}", re.IGNORECASE),
-        re.compile(r"\b(((Executive\s*Order)|(EO)|(E\.\s*O\.\s*))\s*\)?\s*[0-9]{5})", re.IGNORECASE)
+        re.compile(r"\b(((Executive ?Order)|(EO)|(E\. ?O\. ?)) ?\)? ?[0-9]{5})", re.IGNORECASE)
     )
     ref_dict["AR"] =(
-        re.compile(r"[0-9]{1,3}\s*-\s*[0-9]{1,3}(\s*-\s*[0-9]{1,3})?", re.IGNORECASE),
-        re.compile(r"\b(((AR)|(Army\s*regulations?))\s*\)?\s*[0-9]{1,3}\s*-\s*[0-9]{1,3}(\s*-\s*[0-9]{1,3})?)",
+        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?", re.IGNORECASE),
+        re.compile(r"\b(((AR)|(Army ?regulations?)) ?\)? ?[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?)",
         re.IGNORECASE)
     )
     ref_dict["AGO"] =(
-        re.compile(r"(19|20)[0-9]{2}\s*-\s*[0-9]{2,3}", re.IGNORECASE),
-        re.compile(r"\b(((AGO)|(Army\s*General\s*Orders?))\s*\)?\s*(19|20)[0-9]{2}\s*-\s*[0-9]{2,3})",
+        re.compile(r"(19|20)[0-9]{2} ?- ?[0-9]{2,3}", re.IGNORECASE),
+        re.compile(r"\b(((AGO)|(Army ?General ?Orders?)) ?\)? ?(19|20)[0-9]{2} ?- ?[0-9]{2,3})",
         re.IGNORECASE)
     )
     ref_dict["ADP"] =(
-        re.compile(r"(([1])|([0-9]{1,2}\s*-\s*[0-9]{1,2}))", re.IGNORECASE),
-        re.compile(r"\b(((ADP)|(Army\s*Doctrine\s*Publications?))\s*\)?\s*(([1])|([0-9]{1,2}\s*-\s*[0-9]{1,2})))",
+        re.compile(r"(([1])|([0-9]{1,2} ?- ?[0-9]{1,2}))", re.IGNORECASE),
+        re.compile(r"\b(((ADP)|(Army ?Doctrine ?Publications?)) ?\)? ?(([1])|([0-9]{1,2} ?- ?[0-9]{1,2})))",
         re.IGNORECASE)
     )
     ref_dict["PAM"] =(
-        re.compile(r"[0-9]{1,3}\s*-\s*[0-9]{1,3}(\s*-\s*[0-9]{1,3})?", re.IGNORECASE),
-        re.compile(r"\b(((PAM)|(DA\s*Pam(phlets?)?))\s*\)?\s*[0-9]{1,3}\s*-\s*[0-9]{1,3}(\s*-\s*[0-9]{1,3})?)",
+        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?", re.IGNORECASE),
+        re.compile(r"\b(((PAM)|(DA ?Pam(phlets?)?)) ?\)? ?[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?)",
         re.IGNORECASE)
     )
     ref_dict["ATP"] =(
-        re.compile(r"[0-9]\s*-\s*[0-9]{1,2}(\.[0-9]{1,2}(\s*-\s*[0-9]{1,2})?)?", re.IGNORECASE),
-        re.compile(r"\b(((ATP)|(Army\s*Techniques\s*Publications?))\s*\)?\s*[0-9]\s*-\s*[0-9]{1,2}(\.[0-9]{1,2}(\s*-\s*[0-9]{1,2})?)?)",
+        re.compile(r"[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2}( ?- ?[0-9]{1,2})?)?", re.IGNORECASE),
+        re.compile(r"\b(((ATP)|(Army ?Techniques ?Publications?)) ?\)? ?[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2}( ?- ?[0-9]{1,2})?)?)",
         re.IGNORECASE)
     )
     ref_dict["ARMY"] =(
-        re.compile(r"20[0-9]{2}\s*-\s*[0-9]{2}(\s*-\s*[0-9]{1,2})?", re.IGNORECASE),
-        re.compile(r"\b(((ARMY\s*DIR)|(ARMY\s*Directives?))\s*\)?\s*20[0-9]{2}\s*-\s*[0-9]{2}(\s*-\s*[0-9]{1,2})?)",
+        re.compile(r"20[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{1,2})?", re.IGNORECASE),
+        re.compile(r"\b(((ARMY ?DIR)|(ARMY ?Directives?)) ?\)? ?20[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{1,2})?)",
         re.IGNORECASE)
     )
     ref_dict["TC"] =(
-        re.compile(r"[0-9]{1,2}\s*-\s*((HEAT)|([0-9]{1,3}(\s*(\.|-)\s*[0-9]{1,3}(\s*-\s*[0-9])?A?)?))", re.IGNORECASE),
-        re.compile(r"\b(((TC)|(Training\s*Circular))\s*\)?\s*[0-9]{1,2}\s*-\s*((HEAT)|([0-9]{1,3}(\s*(\.|-)\s*[0-9]{1,3}(\s*-\s*[0-9])?A?)?)))",
+        re.compile(r"[0-9]{1,2} ?- ?((HEAT)|([0-9]{1,3}( ?(\.|-) ?[0-9]{1,3}( ?- ?[0-9])?A?)?))", re.IGNORECASE),
+        re.compile(r"\b(((TC)|(Training ?Circular)) ?\)? ?[0-9]{1,2} ?- ?((HEAT)|([0-9]{1,3}( ?(\.|-) ?[0-9]{1,3}( ?- ?[0-9])?A?)?)))",
         re.IGNORECASE)
     )
     ref_dict["STP"] =(
-        re.compile(r"[0-9]{1,2}\s*-\s*[A-Z0-9]{1,6}(\s*-\s*[A-Z]{2,4}(\s*-\s*[A-Z]{2})?)?", re.IGNORECASE),
-        re.compile(r"\b(((STP)|(Soldier\s*Training\s*Publication))\s*\)?\s*[0-9]{1,2}\s*-\s*[A-Z0-9]{1,6}(\s*-\s*[A-Z]{2,4}(\s*-\s*[A-Z]{2})?)?)",
+        re.compile(r"[0-9]{1,2} ?- ?[A-Z0-9]{1,6}( ?- ?[A-Z]{2,4}( ?- ?[A-Z]{2})?)?", re.IGNORECASE),
+        re.compile(r"\b(((STP)|(Soldier ?Training ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[A-Z0-9]{1,6}( ?- ?[A-Z]{2,4}( ?- ?[A-Z]{2})?)?)",
         re.IGNORECASE)
     )
     ref_dict["TB"] =(
-        re.compile(r"((ENG\s*[0-9]{2,3})|([0-9]{3}\s*-\s*[0-9]{1,2})|(MED\s*[0-9]{1,3}(\s*-\s*[0-9]{1,2})?)|([0-9]{1,2}\s*-\s*[0-9]{3,4}(\s*-\s*([0-9]{3}\s*-\s*[0-9]{2})|([A-Z]{3}))?))", re.IGNORECASE),
-        re.compile(r"\b(((TB)|(Technical\s*Bulletins?))\s*\)?\s*((ENG\s*[0-9]{2,3})|([0-9]{3}\s*-\s*[0-9]{1,2})|(MED\s*[0-9]{1,3}(\s*-\s*[0-9]{1,2})?)|([0-9]{1,2}\s*-\s*[0-9]{3,4}(\s*-\s*([0-9]{3}\s*-\s*[0-9]{2})|([A-Z]{3}))?)))",
+        re.compile(r"((ENG ?[0-9]{2,3})|([0-9]{3} ?- ?[0-9]{1,2})|(MED ?[0-9]{1,3}( ?- ?[0-9]{1,2})?)|([0-9]{1,2} ?- ?[0-9]{3,4}( ?- ?([0-9]{3} ?- ?[0-9]{2})|([A-Z]{3}))?))", re.IGNORECASE),
+        re.compile(r"\b(((TB)|(Technical ?Bulletins?)) ?\)? ?((ENG ?[0-9]{2,3})|([0-9]{3} ?- ?[0-9]{1,2})|(MED ?[0-9]{1,3}( ?- ?[0-9]{1,2})?)|([0-9]{1,2} ?- ?[0-9]{3,4}( ?- ?([0-9]{3} ?- ?[0-9]{2})|([A-Z]{3}))?)))",
         re.IGNORECASE)
     )
     ref_dict["DA"] =(
-        re.compile(r"[0-9]{1,3}\s*-\s*[0-9]{1,3}(\s*-\s*[0-9]{2})?", re.IGNORECASE),
-        re.compile(r"\b(((DA\s*MEMO)|(DA\s*MEMORANDUMS?))\s*\)?\s*[0-9]{1,3}\s*-\s*[0-9]{1,3}(\s*-\s*[0-9]{2})?)",
+        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{2})?", re.IGNORECASE),
+        re.compile(r"\b(((DA ?MEMO)|(DA ?MEMORANDUMS?)) ?\)? ?[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{2})?)",
         re.IGNORECASE)
     )
     ref_dict["FM"] =(
-        re.compile(r"[0-9]{1,3}\s*-\s*([0-9]{1,3}(\s*(\.|-)\s*[0-9]{1,2}(\s*-\s*[A-Z]{2})?)?)", re.IGNORECASE),
-        re.compile(r"\b(((FM)|(Field\s*Manual))\s*\)?\s*[0-9]{1,3}\s*-\s*([0-9]{1,3}(\s*(\.|-)\s*[0-9]{1,2}(\s*-\s*[A-Z]{2})?)?))",
+        re.compile(r"[0-9]{1,3} ?- ?([0-9]{1,3}( ?(\.|-) ?[0-9]{1,2}( ?- ?[A-Z]{2})?)?)", re.IGNORECASE),
+        re.compile(r"\b(((FM)|(Field ?Manual)) ?\)? ?[0-9]{1,3} ?- ?([0-9]{1,3}( ?(\.|-) ?[0-9]{1,2}( ?- ?[A-Z]{2})?)?))",
         re.IGNORECASE)
     )
     ref_dict["GTA"] =(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{2}(\s*-\s*[0-9]{3})?[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((GTA)|(Graphic\s*Training\s*Aid))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{2}(\s*-\s*[0-9]{3})?[A-Z]?)",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{3})?[A-Z]?", re.IGNORECASE),
+        re.compile(r"\b(((GTA)|(Graphic ?Training ?Aid)) ?\)? ?[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{3})?[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["HQDA"] =(
-        re.compile(r"[0-9]{1,3}\s*-\s*[0-9]{1}", re.IGNORECASE),
-        re.compile(r"\b((HQDA\s*POLICY\s*NOTICE)\s*[0-9]{1,3}\s*-\s*[0-9]{1})",
+        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1}", re.IGNORECASE),
+        re.compile(r"\b((HQDA ?POLICY ?NOTICE) ?[0-9]{1,3} ?- ?[0-9]{1})",
         re.IGNORECASE)
     )
     ref_dict["CTA"] =(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b(((CTA)|(Common\s*Table\s*of\s*Allowances?))\s*\)?\s*[[0-9]{1,2}\s*-\s*[0-9]{3})",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{3}", re.IGNORECASE),
+        re.compile(r"\b(((CTA)|(Common ?Table ?of ?Allowances?)) ?\)? ?[[0-9]{1,2} ?- ?[0-9]{3})",
         re.IGNORECASE)
     )
     ref_dict["ATTP"] =(
-        re.compile(r"[0-9]{1}\s*-\s*[0-9]{2}\s*\.\s*[0-9]{2}", re.IGNORECASE),
-        re.compile(r"\b(((ATTP)|(ARMY\s*TACTICS,?\s*TECHNIQUES\s*AND\s*PROCEDURES?))\s*\)?\s*[0-9]{1}\s*-\s*[0-9]{2}\s*\.\s*[0-9]{2})",
+        re.compile(r"[0-9]{1} ?- ?[0-9]{2} ?\. ?[0-9]{2}", re.IGNORECASE),
+        re.compile(r"\b(((ATTP)|(ARMY ?TACTICS,? ?TECHNIQUES ?AND ?PROCEDURES?)) ?\)? ?[0-9]{1} ?- ?[0-9]{2} ?\. ?[0-9]{2})",
         re.IGNORECASE)
     )
     ref_dict["TM"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[A-Z0-9]{1,4}(\.[0-9]{2})?(\s*-\s*[A-Z0-9&]{1,4})*", re.IGNORECASE),
-        re.compile(r"\b(((TM)|(Technical\s*Manuals?))\s*\)?\s*[0-9]{1,2}\s*-\s*[A-Z0-9]{1,4}(\.[0-9]{2})?(\s*-\s*[A-Z0-9&]{1,4})*)", re.IGNORECASE)
+        re.compile(r"[0-9]{1,2} ?- ?[A-Z0-9]{1,4}(\.[0-9]{2})?( ?- ?[A-Z0-9&]{1,4})*", re.IGNORECASE),
+        re.compile(r"\b(((TM)|(Technical ?Manuals?)) ?\)? ?[0-9]{1,2} ?- ?[A-Z0-9]{1,4}(\.[0-9]{2})?( ?- ?[A-Z0-9&]{1,4})*)", re.IGNORECASE)
     )
     ref_dict["AFI"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[A-Z0-9-_]+", re.IGNORECASE),
-        re.compile(r"\b(((AFI)|(Air\s*Force\s*Instructions?))\s*\)?\s*[0-9]{1,2}\s*-\s*[A-Z0-9-_]+)", re.IGNORECASE)
+        re.compile(r"[0-9]{1,2} ?- ?[A-Z0-9-_]+", re.IGNORECASE),
+        re.compile(r"\b(((AFI)|(Air ?Force ?Instructions?)) ?\)? ?[0-9]{1,2} ?- ?[A-Z0-9-_]+)", re.IGNORECASE)
     )
     ref_dict["CFETP"]=(
         re.compile(r"[A-Z0-9]*[0-9][A-Z0-9-_]+", re.IGNORECASE),
-        re.compile(r"\b(((CFETP)|(CAREER\s*FIELD\s*EDUCATION\s*(AND|&)\s*TRAINING\s*PLAN))\s*\)?\s*[A-Z0-9]*[0-9][A-Z0-9-_]+)",
+        re.compile(r"\b(((CFETP)|(CAREER ?FIELD ?EDUCATION ?(AND|&) ?TRAINING ?PLAN)) ?\)? ?[A-Z0-9]*[0-9][A-Z0-9-_]+)",
         re.IGNORECASE)
     )
     ref_dict["AFMAN"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[A-Z0-9-_]+", re.IGNORECASE),
-        re.compile(r"\b(((AFMAN)|(AIR\s*FORCE\s*MANUAL))\s*\)?\s*[0-9]{2}\s*-\s*[A-Z0-9-_]+)",
+        re.compile(r"[0-9]{2} ?- ?[A-Z0-9-_]+", re.IGNORECASE),
+        re.compile(r"\b(((AFMAN)|(AIR ?FORCE ?MANUAL)) ?\)? ?[0-9]{2} ?- ?[A-Z0-9-_]+)",
         re.IGNORECASE)
     )
     ref_dict["QTP"]=(
-        re.compile(r"[0-9][0-9A-Z]{1,6}(\s*-\s*[0-9A-Z]{1,6}){0,2}", re.IGNORECASE),
-        re.compile(r"\b(((QTP)|(QUALIFICATION\s*TRAINING\s*PACKAGE))\s*\)?\s*[0-9][0-9A-Z]{1,6}(\s*-\s*[0-9A-Z]{1,6}){0,2})",
+        re.compile(r"[0-9][0-9A-Z]{1,6}( ?- ?[0-9A-Z]{1,6}){0,2}", re.IGNORECASE),
+        re.compile(r"\b(((QTP)|(QUALIFICATION ?TRAINING ?PACKAGE)) ?\)? ?[0-9][0-9A-Z]{1,6}( ?- ?[0-9A-Z]{1,6}){0,2})",
         re.IGNORECASE)
     )
     ref_dict["AFPD"]=(
-        re.compile(r"((1)|([0-9]{2}\s*-\s*[0-9]{1,2}(\s*-\s*[A-Z]{1})?))", re.IGNORECASE),
-        re.compile(r"\b(((AFPD)|(AIR\s*FORCE\s*POLICY\s*DIRECTIVE))\s*\)?\s*((1)|([0-9]{2}\s*-\s*[0-9]{1,2}(\s*-\s*[A-Z]{1})?)))",
+        re.compile(r"((1)|([0-9]{2} ?- ?[0-9]{1,2}( ?- ?[A-Z]{1})?))", re.IGNORECASE),
+        re.compile(r"\b(((AFPD)|(AIR ?FORCE ?POLICY ?DIRECTIVE)) ?\)? ?((1)|([0-9]{2} ?- ?[0-9]{1,2}( ?- ?[A-Z]{1})?)))",
         re.IGNORECASE)
     )
     ref_dict["AFTTP"]=(
-        re.compile(r"[0-9]\s*-\s*[0-9]{1,2}(\.[0-9]{1,2})?((V[0-9])|(_[A-Z]{2}))?", re.IGNORECASE),
-        re.compile(r"\b(((AFTTP)|(Air\s*Force\s*Tactics?,?\s*Techniques?,?\s*(and|&)?\s*Procedures?))\s*\)?\s*[0-9]\s*-\s*[0-9]{1,2}(\.[0-9]{1,2})?((V[0-9])|(_[A-Z]{2}))?)",
+        re.compile(r"[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2})?((V[0-9])|(_[A-Z]{2}))?", re.IGNORECASE),
+        re.compile(r"\b(((AFTTP)|(Air ?Force ?Tactics?,? ?Techniques?,? ?(and|&)? ?Procedures?)) ?\)? ?[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2})?((V[0-9])|(_[A-Z]{2}))?)",
         re.IGNORECASE)
     )
     ref_dict["AFVA"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{1,4}", re.IGNORECASE),
-        re.compile(r"\b(((AFVA)|(Air\s*Force\s*Visual\s*Aids?))\s*\)?\s*[0-9]{1,2}\s*-\s*[0-9]{1,4})",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{1,4}", re.IGNORECASE),
+        re.compile(r"\b(((AFVA)|(Air ?Force ?Visual ?Aids?)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{1,4})",
         re.IGNORECASE)
     )
     ref_dict["AFH"]=(
-        re.compile(r"((1)|(([0-9]{1,2}\s*-\s*[0-9]{3,4})((\s*\(\s*I\s*\))|(\s*V\s*[0-9]{1,2})|(\s*,\s*Vol(ume)?\s*[0-9]{1,2}))?))", re.IGNORECASE),
-        re.compile(r"\b(((AFH)|(Air\s*Force\s*Handbook))\s*\)?\s*((1)|(([0-9]{1,2}\s*-\s*[0-9]{3,4})((\s*\(\s*I\s*\))|(\s*V\s*[0-9]{1,2})|(\s*,\s*Vol(ume)?\s*[0-9]{1,2}))?)))",
+        re.compile(r"((1)|(([0-9]{1,2} ?- ?[0-9]{3,4})(( ?\( ?I ?\))|( ?V ?[0-9]{1,2})|( ?, ?Vol(ume)? ?[0-9]{1,2}))?))", re.IGNORECASE),
+        re.compile(r"\b(((AFH)|(Air ?Force ?Handbook)) ?\)? ?((1)|(([0-9]{1,2} ?- ?[0-9]{3,4})(( ?\( ?I ?\))|( ?V ?[0-9]{1,2})|( ?, ?Vol(ume)? ?[0-9]{1,2}))?)))",
         re.IGNORECASE)
     )
     ref_dict["HAFMD"]=(
-        re.compile(r"[0-9]\s*-\s*[0-9]{1,2}(\s*ADDENDUM\s*[A-Z])?", re.IGNORECASE),
-        re.compile(r"\b(((HAFMD)|(HEADQUARTERS\s*AIR\s*FORCE\s*MISSION\s*DIRECTIVE))\s*\)?\s*[0-9]\s*-\s*[0-9]{1,2}(\s*ADDENDUM\s*[A-Z])?)",
+        re.compile(r"[0-9] ?- ?[0-9]{1,2}( ?ADDENDUM ?[A-Z])?", re.IGNORECASE),
+        re.compile(r"\b(((HAFMD)|(HEADQUARTERS ?AIR ?FORCE ?MISSION ?DIRECTIVE)) ?\)? ?[0-9] ?- ?[0-9]{1,2}( ?ADDENDUM ?[A-Z])?)",
         re.IGNORECASE)
     )
     ref_dict["AFPAM"]=(
-        re.compile(r"(\(\s*I\s*\)\s*)?[0-9]{2}\s*-\s*[0-9]{3,4}(\s*V\s*[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((AFPAM)|(Air\s*Force\s*Pamphlet))\s*\)?\s*(\(\s*I\s*\)\s*)?[0-9]{2}\s*-\s*[0-9]{3,4}(\s*V\s*[0-9])?)",
+        re.compile(r"(\( ?I ?\) ?)?[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?", re.IGNORECASE),
+        re.compile(r"\b(((AFPAM)|(Air ?Force ?Pamphlet)) ?\)? ?(\( ?I ?\) ?)?[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?)",
         re.IGNORECASE)
     )
     ref_dict["AFMD"]=(
         re.compile(r"[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b(((AFMD)|(Air\s*Force\s*MISSION\s*DIRECTIVE))\s*\)?\s*[0-9]{1,2})", re.IGNORECASE)
+        re.compile(r"\b(((AFMD)|(Air ?Force ?MISSION ?DIRECTIVE)) ?\)? ?[0-9]{1,2})", re.IGNORECASE)
     )
     ref_dict["AFM"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{2}", re.IGNORECASE),
-        re.compile(r"\b(((AFM)|(Air\s*Force\s*Manual))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{2})",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{2}", re.IGNORECASE),
+        re.compile(r"\b(((AFM)|(Air ?Force ?Manual)) ?\)? ?[0-9]{2} ?- ?[0-9]{2})",
         re.IGNORECASE)
     )
     ref_dict["HOI"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b(((HOI)|(HEADQUARTERS\s*OPERATING\s*INSTRUCTION))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{1,2})",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{1,2}", re.IGNORECASE),
+        re.compile(r"\b(((HOI)|(HEADQUARTERS ?OPERATING ?INSTRUCTION)) ?\)? ?[0-9]{2} ?- ?[0-9]{1,2})",
         re.IGNORECASE)
     )
     ref_dict["AFJQS"]=(
-        re.compile(r"[0-9][0-9A-Z]{4}(\s*-\s*[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((AFJQS)|(Air\s*Force\s*Job\s*Qualification\s*Standard))\s*\)?\s*[0-9][0-9A-Z]{4}(\s*-\s*[0-9])?)",
+        re.compile(r"[0-9][0-9A-Z]{4}( ?- ?[0-9])?", re.IGNORECASE),
+        re.compile(r"\b(((AFJQS)|(Air ?Force ?Job ?Qualification ?Standard)) ?\)? ?[0-9][0-9A-Z]{4}( ?- ?[0-9])?)",
         re.IGNORECASE)
     )
     ref_dict["AFJI"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{3,4}", re.IGNORECASE),
-        re.compile(r"\b(((AFJI)|(Air\s*Force\s*Joint\s*Instruction))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{3,4})",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{3,4}", re.IGNORECASE),
+        re.compile(r"\b(((AFJI)|(Air ?Force ?Joint ?Instruction)) ?\)? ?[0-9]{2} ?- ?[0-9]{3,4})",
         re.IGNORECASE)
     )
     ref_dict["AFGM"]=(
-        re.compile(r"[0-9]{4}\s*-\s*[0-9]{2}\s*-\s*[0-9]{2}([0-9]\s*-\s*[0-9]{2})?", re.IGNORECASE),
-        re.compile(r"\b(((AFGM)|(Air\s*Force\s*Guidance\s*Memorandum))\s*\)?\s*[0-9]{4}\s*-\s*[0-9]{2}\s*-\s*[0-9]{2}([0-9]\s*-\s*[0-9]{2})?)",
+        re.compile(r"[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}([0-9] ?- ?[0-9]{2})?", re.IGNORECASE),
+        re.compile(r"\b(((AFGM)|(Air ?Force ?Guidance ?Memorandum)) ?\)? ?[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}([0-9] ?- ?[0-9]{2})?)",
         re.IGNORECASE)
     )
     ref_dict["DAFI"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{3,4}(\s*V\s*[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((DAFI)|(Department\s*of\s*the\s*Air\s*Force\s*Instruction))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{3,4}(\s*V\s*[0-9])?)",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?", re.IGNORECASE),
+        re.compile(r"\b(((DAFI)|(Department ?of ?the ?Air ?Force ?Instruction)) ?\)? ?[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?)",
         re.IGNORECASE)
     )
     ref_dict["AF"]=(
         re.compile(r"[0-9]{1,4}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((AF)|(Air\s*Force))\s*\)?\s*(Form\s*)?[0-9]{1,4}[A-Z]?)",
+        re.compile(r"\b(((AF)|(Air ?Force)) ?\)? ?(Form ?)?[0-9]{1,4}[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["SF"]=(
-        re.compile(r"[0-9]{2,4}(\s*-\s*[0-9])?[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b((SF)\s*\)?\s*[0-9]{2,4}(\s*-\s*[0-9])?[A-Z]?)",
+        re.compile(r"[0-9]{2,4}( ?- ?[0-9])?[A-Z]?", re.IGNORECASE),
+        re.compile(r"\b((SF) ?\)? ?[0-9]{2,4}( ?- ?[0-9])?[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["AFPM"]=(
-        re.compile(r"[0-9]{4}\s*-\s*[0-9]{2}\s*-\s*[0-9]{2}", re.IGNORECASE),
-        re.compile(r"\b(((AFPM)|(Air\s*Force\s*Policy\s*Memorandum))\s*\)?\s*[0-9]{4}\s*-\s*[0-9]{2}\s*-\s*[0-9]{2})",
+        re.compile(r"[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}", re.IGNORECASE),
+        re.compile(r"\b(((AFPM)|(Air ?Force ?Policy ?Memorandum)) ?\)? ?[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2})",
         re.IGNORECASE)
     )
     ref_dict["AFJMAN"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b(((AFJMAN)|(Air\s*Force\s*Joint\sManual))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{3})",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{3}", re.IGNORECASE),
+        re.compile(r"\b(((AFJMAN)|(Air ?Force ?Joint\sManual)) ?\)? ?[0-9]{2} ?- ?[0-9]{3})",
         re.IGNORECASE)
     )
     ref_dict["JTA"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{1,3}", re.IGNORECASE),
-        re.compile(r"\b(((JTA)|(Joint\s*Table\s*of\sAllowances?))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{1,3})",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{1,3}", re.IGNORECASE),
+        re.compile(r"\b(((JTA)|(Joint ?Table ?of\sAllowances?)) ?\)? ?[0-9]{2} ?- ?[0-9]{1,3})",
         re.IGNORECASE)
     )
     ref_dict["DAFPD"]=(
-        re.compile(r"[0-9]{2}\s*-\s*[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b(((DAFPD)|(Department\s*of\s*\the\s*Air\s*Force\s*Policy\s*Directive))\s*\)?\s*[0-9]{2}\s*-\s*[0-9]{1,2})",
+        re.compile(r"[0-9]{2} ?- ?[0-9]{1,2}", re.IGNORECASE),
+        re.compile(r"\b(((DAFPD)|(Department ?of ?\the ?Air ?Force ?Policy ?Directive)) ?\)? ?[0-9]{2} ?- ?[0-9]{1,2})",
         re.IGNORECASE)
     )
     ref_dict["MCO"]=(
         re.compile(r"P?[0-9]{4,5}[A-Z]?\.[0-9]{1,3}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((MCO)|(Marine\s*Corps\s*Orders?))\s*\)?\s*P?[0-9]{4,5}[A-Z]?\.[0-9]{1,3}[A-Z]?)",
+        re.compile(r"\b(((MCO)|(Marine ?Corps ?Orders?)) ?\)? ?P?[0-9]{4,5}[A-Z]?\.[0-9]{1,3}[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["MCBUL"]=(
         re.compile(r"[0-9]{4,5}", re.IGNORECASE),
-        re.compile(r"\b(((MCBUL)|(MARINE\s*CORPS\s*BULLETIN))\s*\)?\s*[0-9]{4,5})",
+        re.compile(r"\b(((MCBUL)|(MARINE ?CORPS ?BULLETIN)) ?\)? ?[0-9]{4,5})",
         re.IGNORECASE)
     )
     ref_dict["NAVMC"]=(
-        re.compile(r"[0-9]{4}((\.[0-9]{1,3}[A-Z]?)|(\s*-\s*[A-Z]))?", re.IGNORECASE),
-        re.compile(r"\b((NAVMC)\s*\)?\s*[0-9]{4}((\.[0-9]{1,3}[A-Z]?)|(\s*-\s*[A-Z]))?)",
+        re.compile(r"[0-9]{4}((\.[0-9]{1,3}[A-Z]?)|( ?- ?[A-Z]))?", re.IGNORECASE),
+        re.compile(r"\b((NAVMC) ?\)? ?[0-9]{4}((\.[0-9]{1,3}[A-Z]?)|( ?- ?[A-Z]))?)",
         re.IGNORECASE)
     )
     ref_dict["NAVMC DIR"]=(
         re.compile(r"[0-9]{4}.[0-9]{1,3}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((NAVMC\s*DIR)|(NAVMC\s*Directive))\s*\)?\s*[0-9]{4}.[0-9]{1,3}[A-Z]?)",
+        re.compile(r"\b(((NAVMC ?DIR)|(NAVMC ?Directive)) ?\)? ?[0-9]{4}.[0-9]{1,3}[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["MCRP"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{1,2}[A-Z]?(\.[0-9]{1-2}[A-Z]?)?", re.IGNORECASE),
-        re.compile(r"\b(((MCRP)|(MARINE\s*CORPS\s*Reference\s*Publication))\s*\)?\s*[0-9]{1,2}\s*-\s*[0-9]{1,2}[A-Z]?(\.[0-9]{1-2}[A-Z]?)?)",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{1,2}[A-Z]?(\.[0-9]{1-2}[A-Z]?)?", re.IGNORECASE),
+        re.compile(r"\b(((MCRP)|(MARINE ?CORPS ?Reference ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{1,2}[A-Z]?(\.[0-9]{1-2}[A-Z]?)?)",
         re.IGNORECASE)
     )
     ref_dict["MCTP"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{2}[A-Z]", re.IGNORECASE),
-        re.compile(r"\b(((MCTP)|(MARINE\s*CORPS\s*Tactical\s*Publication))\s*\)?\s*[0-9]{1,2}\s*-\s*[0-9]{2}[A-Z])",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{2}[A-Z]", re.IGNORECASE),
+        re.compile(r"\b(((MCTP)|(MARINE ?CORPS ?Tactical ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{2}[A-Z])",
         re.IGNORECASE)
     )
     ref_dict["MCWP"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{2}(\.[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((MCWP)|(MARINE\s*CORPS\s*Warfighting\s*Publication))\s*\)?\s*[0-9]{1,2}\s*-\s*[0-9]{2}(\.[0-9])?)",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{2}(\.[0-9])?", re.IGNORECASE),
+        re.compile(r"\b(((MCWP)|(MARINE ?CORPS ?Warfighting ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{2}(\.[0-9])?)",
         re.IGNORECASE)
     )
     ref_dict["MCDP"]=(
-        re.compile(r"[0-9](\s*-\s*[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((MCDP)|(MARINE\s*CORPS\s*Doctrinal\s*Publication))\s*\)?\s*[0-9](\s*-\s*[0-9])?)",
+        re.compile(r"[0-9]( ?- ?[0-9])?", re.IGNORECASE),
+        re.compile(r"\b(((MCDP)|(MARINE ?CORPS ?Doctrinal ?Publication)) ?\)? ?[0-9]( ?- ?[0-9])?)",
         re.IGNORECASE)
     )
     ref_dict["MCIP"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{2}([A-Z]{1,2})?(\.?[0-9]{1,2}[A-Z]?)?", re.IGNORECASE),
-        re.compile(r"\b(((MCIP)|(MARINE\s*CORPS\s*Interim\s*Publication))\s*\)?\s*[0-9]{1,2}\s*-\s*[0-9]{2}([A-Z]{1,2})?(\.?[0-9]{1,2}[A-Z]?)?)",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{2}([A-Z]{1,2})?(\.?[0-9]{1,2}[A-Z]?)?", re.IGNORECASE),
+        re.compile(r"\b(((MCIP)|(MARINE ?CORPS ?Interim ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{2}([A-Z]{1,2})?(\.?[0-9]{1,2}[A-Z]?)?)",
         re.IGNORECASE)
     )
     ref_dict["FMFRP"]=(
-        re.compile(r"[0-9]{1,2}\s*-\s*[0-9]{1,3}(\s*-\s*I+)?", re.IGNORECASE),
-        re.compile(r"\b(((FMFRP)|(Fleet\s*Marine\s*Force\s*Reference\s*Publication))\s*\)?\s*[0-9]{1,2}\s*-\s*[0-9]{1,3}(\s*-\s*I+)?)",
+        re.compile(r"[0-9]{1,2} ?- ?[0-9]{1,3}( ?- ?I+)?", re.IGNORECASE),
+        re.compile(r"\b(((FMFRP)|(Fleet ?Marine ?Force ?Reference ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{1,3}( ?- ?I+)?)",
         re.IGNORECASE)
     )
     ref_dict["FMFM"]=(
-        re.compile(r"[0-9]\s*-\s*[0-9]{1,2}(\s*-\s*[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((FMFM)|(Fleet\s*Marine\s*Force\s*Manuals?))\s*\)?\s*[0-9]\s*-\s*[0-9]{1,2}(\s*-\s*[0-9])?)",
+        re.compile(r"[0-9] ?- ?[0-9]{1,2}( ?- ?[0-9])?", re.IGNORECASE),
+        re.compile(r"\b(((FMFM)|(Fleet ?Marine ?Force ?Manuals?)) ?\)? ?[0-9] ?- ?[0-9]{1,2}( ?- ?[0-9])?)",
         re.IGNORECASE)
     )
     ref_dict["IRM"]=(
-        re.compile(r"(-\s*)?[0-9]{4}\s*-\s*[0-9]{2}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((IRM)|(Information\s*Resource\s*Management))\s*\)?\s*(-\s*)?[0-9]{4}\s*-\s*[0-9]{2}[A-Z]?)",
+        re.compile(r"(- ?)?[0-9]{4} ?- ?[0-9]{2}[A-Z]?", re.IGNORECASE),
+        re.compile(r"\b(((IRM)|(Information ?Resource ?Management)) ?\)? ?(- ?)?[0-9]{4} ?- ?[0-9]{2}[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["SECNAVINST"]=(
         re.compile(r"[0-9]{4}\.[0-9]{1,2}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((SECNAVINST)|(SECNAV\s*INSTRUCTION))\s*\)?\s*[0-9]{4}\.[0-9]{1,2}[A-Z]?)",
+        re.compile(r"\b(((SECNAVINST)|(SECNAV ?INSTRUCTION)) ?\)? ?[0-9]{4}\.[0-9]{1,2}[A-Z]?)",
         re.IGNORECASE)
     )
     ref_dict["SECNAV"]=(
-        re.compile(r"M\s*-\s*[0-9]{4}\.[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b((SECNAV)\s*\)?\s*M\s*-\s*[0-9]{4}\.[0-9]{1,2})",
+        re.compile(r"M ?- ?[0-9]{4}\.[0-9]{1,2}", re.IGNORECASE),
+        re.compile(r"\b((SECNAV) ?\)? ?M ?- ?[0-9]{4}\.[0-9]{1,2})",
         re.IGNORECASE)
     )
     ref_dict["NAVSUP"]=(
-        re.compile(r"((P\s*-\s*)|(Publication\s*))[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b((NAVSUP)\s*\)?\s*((P\s*-\s*)|(Publication\s*))[0-9]{3})",
+        re.compile(r"((P ?- ?)|(Publication ?))[0-9]{3}", re.IGNORECASE),
+        re.compile(r"\b((NAVSUP) ?\)? ?((P ?- ?)|(Publication ?))[0-9]{3})",
         re.IGNORECASE)
     )
     ref_dict["JAGINST"]=(
         re.compile(r"[0-9]{4,5}(\.[0-9]{1,2}[A-Z]?)?", re.IGNORECASE),
-        re.compile(r"\b(((JAGINST)|(JAG\s*Instruction))\s*\)?\s*[0-9]{4,5}(\.[0-9]{1,2}[A-Z]?)?)",
+        re.compile(r"\b(((JAGINST)|(JAG ?Instruction)) ?\)? ?[0-9]{4,5}(\.[0-9]{1,2}[A-Z]?)?)",
         re.IGNORECASE)
     )
     ref_dict["OMBM"]=(

--- a/common/document_parser/ref_utils.py
+++ b/common/document_parser/ref_utils.py
@@ -1,360 +1,288 @@
 import re
 
+
 def make_dict():
+    # Each pattern should have only 1 capturing group that is the numerical
+    # part of the reference.
     ref_dict = {}
-    ref_dict['DoD'] = (
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b(((dod ?placeholder)|(dod)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["DoDD"] = (
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b(((dod ?directives?)|(dodd)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["DoDI"] = (
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b(((dod ?instruction)|(dodi)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["DoDM"] = (
-        re.compile(r"([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}(( ?,* ?Volume ?[0-9]+)|( ?(- ?V[0-9])))?", re.IGNORECASE),
-        re.compile(r"\b(((dod ?manual)|(dodm)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}(( ?,* ?Volume ?[0-9]+)|( ?(- ?V[0-9])))?)",
-        re.IGNORECASE)
-    )
-    ref_dict["DTM"] =(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b(((DTM)|(DT ?Memorandum)) ?\)? ?-? ?[0-9]{2} ?- ?[0-9]{3})", re.IGNORECASE)
-    )
-    ref_dict["AI"] =(
-        re.compile(r"([0-9]+)", re.IGNORECASE),
-        re.compile(r"\b(((administrative ?instruction)|(ai)) ?\)? ?[0-9]+)", re.IGNORECASE)
-    )
-    ref_dict["Title"] =(
-        re.compile(r"([0-9]{1,2})", re.IGNORECASE),
-        re.compile(r"\b((Title) ?[0-9]{1,2})", re.IGNORECASE)
-    )
-    ref_dict["ICD"] =(
-        re.compile(r"([0-9]{1,3})", re.IGNORECASE),
-        re.compile(r"\b(((Intelligence ?Community ?Directive)|(ICD)) ?\)? ?[0-9]{1,3})", re.IGNORECASE)
-    )
-    ref_dict["ICPG"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{3}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE),
-        re.compile(r"\b((icpg) ?([A-Z]+-)?[0-9]{3}\. ?[0-9]{1,3} ?(-[A-Z]+)?([E])?)", re.IGNORECASE)
-    )
-    ref_dict["ICPM"] =(
-        re.compile(r"([0-9]{4}- ?[0-9]{3}- ?[0-9]{1})", re.IGNORECASE),
-        re.compile(r"\b((icpm) ?[0-9]{4}- ?[0-9]{3}- ?[0-9]{1})", re.IGNORECASE)
-    )
-    ref_dict["CJCSI"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs ?instruction)|(cjcsi)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["CJCSM"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs ?manual)|(cjcsm)) ?\)? ?([A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}([A-Z])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["CJCSG"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4} ?([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs ?gde)|(cjcsg)) ?\)? ?([A-Z]+-)?[0-9]{4} ?([A-Z])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["CJCSN"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{4}(\. ?[0-9]{0,3}([A-Z])?)?)", re.IGNORECASE),
-        re.compile(r"\b(((cjcs ?notice)|(cjcsn)) ?\)? ?([A-Z]+-)?[0-9]{4}(\. ?[0-9]{0,3}([A-Z])?)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["JP"] =(
-        re.compile(r"(([A-Z]+-)?[0-9]{1,2}-[0-9]{1,3}([A-Z])?)", re.IGNORECASE),
-        re.compile(r"\b(((joint ?publication)|(jp)) ?\)? ?([A-Z]+-)?[0-9]{1,2}-[0-9]{1,3}([A-Z])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["DCID"] =(
-        re.compile(r"[0-9]\/[0-9]{1,2}(P)?", re.IGNORECASE),
-        re.compile(r"\b(((Director ?of ?Central ?Intelligence ?Directives)|(DCID)) ?\)? ?[0-9]\/[0-9]{1,2}(P)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["EO"] =(
-        re.compile(r"[0-9]{5}", re.IGNORECASE),
-        re.compile(r"\b(((Executive ?Order)|(EO)|(E\. ?O\. ?)) ?\)? ?[0-9]{5})", re.IGNORECASE)
-    )
-    ref_dict["AR"] =(
-        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?", re.IGNORECASE),
-        re.compile(r"\b(((AR)|(Army ?regulations?)) ?\)? ?[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AGO"] =(
-        re.compile(r"(19|20)[0-9]{2} ?- ?[0-9]{2,3}", re.IGNORECASE),
-        re.compile(r"\b(((AGO)|(Army ?General ?Orders?)) ?\)? ?(19|20)[0-9]{2} ?- ?[0-9]{2,3})",
-        re.IGNORECASE)
-    )
-    ref_dict["ADP"] =(
-        re.compile(r"(([1])|([0-9]{1,2} ?- ?[0-9]{1,2}))", re.IGNORECASE),
-        re.compile(r"\b(((ADP)|(Army ?Doctrine ?Publications?)) ?\)? ?(([1])|([0-9]{1,2} ?- ?[0-9]{1,2})))",
-        re.IGNORECASE)
-    )
-    ref_dict["PAM"] =(
-        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?", re.IGNORECASE),
-        re.compile(r"\b(((PAM)|(DA ?Pam(phlets?)?)) ?\)? ?[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{1,3})?)",
-        re.IGNORECASE)
-    )
-    ref_dict["ATP"] =(
-        re.compile(r"[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2}( ?- ?[0-9]{1,2})?)?", re.IGNORECASE),
-        re.compile(r"\b(((ATP)|(Army ?Techniques ?Publications?)) ?\)? ?[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2}( ?- ?[0-9]{1,2})?)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["ARMY"] =(
-        re.compile(r"20[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{1,2})?", re.IGNORECASE),
-        re.compile(r"\b(((ARMY ?DIR)|(ARMY ?Directives?)) ?\)? ?20[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{1,2})?)",
-        re.IGNORECASE)
-    )
-    ref_dict["TC"] =(
-        re.compile(r"[0-9]{1,2} ?- ?((HEAT)|([0-9]{1,3}( ?(\.|-) ?[0-9]{1,3}( ?- ?[0-9])?A?)?))", re.IGNORECASE),
-        re.compile(r"\b(((TC)|(Training ?Circular)) ?\)? ?[0-9]{1,2} ?- ?((HEAT)|([0-9]{1,3}( ?(\.|-) ?[0-9]{1,3}( ?- ?[0-9])?A?)?)))",
-        re.IGNORECASE)
-    )
-    ref_dict["STP"] =(
-        re.compile(r"[0-9]{1,2} ?- ?[A-Z0-9]{1,6}( ?- ?[A-Z]{2,4}( ?- ?[A-Z]{2})?)?", re.IGNORECASE),
-        re.compile(r"\b(((STP)|(Soldier ?Training ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[A-Z0-9]{1,6}( ?- ?[A-Z]{2,4}( ?- ?[A-Z]{2})?)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["TB"] =(
-        re.compile(r"((ENG ?[0-9]{2,3})|([0-9]{3} ?- ?[0-9]{1,2})|(MED ?[0-9]{1,3}( ?- ?[0-9]{1,2})?)|([0-9]{1,2} ?- ?[0-9]{3,4}( ?- ?([0-9]{3} ?- ?[0-9]{2})|([A-Z]{3}))?))", re.IGNORECASE),
-        re.compile(r"\b(((TB)|(Technical ?Bulletins?)) ?\)? ?((ENG ?[0-9]{2,3})|([0-9]{3} ?- ?[0-9]{1,2})|(MED ?[0-9]{1,3}( ?- ?[0-9]{1,2})?)|([0-9]{1,2} ?- ?[0-9]{3,4}( ?- ?([0-9]{3} ?- ?[0-9]{2})|([A-Z]{3}))?)))",
-        re.IGNORECASE)
-    )
-    ref_dict["DA"] =(
-        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{2})?", re.IGNORECASE),
-        re.compile(r"\b(((DA ?MEMO)|(DA ?MEMORANDUMS?)) ?\)? ?[0-9]{1,3} ?- ?[0-9]{1,3}( ?- ?[0-9]{2})?)",
-        re.IGNORECASE)
-    )
-    ref_dict["FM"] =(
-        re.compile(r"[0-9]{1,3} ?- ?([0-9]{1,3}( ?(\.|-) ?[0-9]{1,2}( ?- ?[A-Z]{2})?)?)", re.IGNORECASE),
-        re.compile(r"\b(((FM)|(Field ?Manual)) ?\)? ?[0-9]{1,3} ?- ?([0-9]{1,3}( ?(\.|-) ?[0-9]{1,2}( ?- ?[A-Z]{2})?)?))",
-        re.IGNORECASE)
-    )
-    ref_dict["GTA"] =(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{3})?[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((GTA)|(Graphic ?Training ?Aid)) ?\)? ?[0-9]{2} ?- ?[0-9]{2}( ?- ?[0-9]{3})?[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["HQDA"] =(
-        re.compile(r"[0-9]{1,3} ?- ?[0-9]{1}", re.IGNORECASE),
-        re.compile(r"\b((HQDA ?POLICY ?NOTICE) ?[0-9]{1,3} ?- ?[0-9]{1})",
-        re.IGNORECASE)
-    )
-    ref_dict["CTA"] =(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b(((CTA)|(Common ?Table ?of ?Allowances?)) ?\)? ?[[0-9]{1,2} ?- ?[0-9]{3})",
-        re.IGNORECASE)
-    )
-    ref_dict["ATTP"] =(
-        re.compile(r"[0-9]{1} ?- ?[0-9]{2} ?\. ?[0-9]{2}", re.IGNORECASE),
-        re.compile(r"\b(((ATTP)|(ARMY ?TACTICS,? ?TECHNIQUES ?AND ?PROCEDURES?)) ?\)? ?[0-9]{1} ?- ?[0-9]{2} ?\. ?[0-9]{2})",
-        re.IGNORECASE)
-    )
-    ref_dict["TM"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[A-Z0-9]{1,4}(\.[0-9]{2})?( ?- ?[A-Z0-9&]{1,4})*", re.IGNORECASE),
-        re.compile(r"\b(((TM)|(Technical ?Manuals?)) ?\)? ?[0-9]{1,2} ?- ?[A-Z0-9]{1,4}(\.[0-9]{2})?( ?- ?[A-Z0-9&]{1,4})*)", re.IGNORECASE)
-    )
-    ref_dict["AFI"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[A-Z0-9-_]+", re.IGNORECASE),
-        re.compile(r"\b(((AFI)|(Air ?Force ?Instructions?)) ?\)? ?[0-9]{1,2} ?- ?[A-Z0-9-_]+)", re.IGNORECASE)
-    )
-    ref_dict["CFETP"]=(
-        re.compile(r"[A-Z0-9]*[0-9][A-Z0-9-_]+", re.IGNORECASE),
-        re.compile(r"\b(((CFETP)|(CAREER ?FIELD ?EDUCATION ?(AND|&) ?TRAINING ?PLAN)) ?\)? ?[A-Z0-9]*[0-9][A-Z0-9-_]+)",
-        re.IGNORECASE)
-    )
-    ref_dict["AFMAN"]=(
-        re.compile(r"[0-9]{2} ?- ?[A-Z0-9-_]+", re.IGNORECASE),
-        re.compile(r"\b(((AFMAN)|(AIR ?FORCE ?MANUAL)) ?\)? ?[0-9]{2} ?- ?[A-Z0-9-_]+)",
-        re.IGNORECASE)
-    )
-    ref_dict["QTP"]=(
-        re.compile(r"[0-9][0-9A-Z]{1,6}( ?- ?[0-9A-Z]{1,6}){0,2}", re.IGNORECASE),
-        re.compile(r"\b(((QTP)|(QUALIFICATION ?TRAINING ?PACKAGE)) ?\)? ?[0-9][0-9A-Z]{1,6}( ?- ?[0-9A-Z]{1,6}){0,2})",
-        re.IGNORECASE)
-    )
-    ref_dict["AFPD"]=(
-        re.compile(r"((1)|([0-9]{2} ?- ?[0-9]{1,2}( ?- ?[A-Z]{1})?))", re.IGNORECASE),
-        re.compile(r"\b(((AFPD)|(AIR ?FORCE ?POLICY ?DIRECTIVE)) ?\)? ?((1)|([0-9]{2} ?- ?[0-9]{1,2}( ?- ?[A-Z]{1})?)))",
-        re.IGNORECASE)
-    )
-    ref_dict["AFTTP"]=(
-        re.compile(r"[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2})?((V[0-9])|(_[A-Z]{2}))?", re.IGNORECASE),
-        re.compile(r"\b(((AFTTP)|(Air ?Force ?Tactics?,? ?Techniques?,? ?(and|&)? ?Procedures?)) ?\)? ?[0-9] ?- ?[0-9]{1,2}(\.[0-9]{1,2})?((V[0-9])|(_[A-Z]{2}))?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AFVA"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{1,4}", re.IGNORECASE),
-        re.compile(r"\b(((AFVA)|(Air ?Force ?Visual ?Aids?)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{1,4})",
-        re.IGNORECASE)
-    )
-    ref_dict["AFH"]=(
-        re.compile(r"((1)|(([0-9]{1,2} ?- ?[0-9]{3,4})(( ?\( ?I ?\))|( ?V ?[0-9]{1,2})|( ?, ?Vol(ume)? ?[0-9]{1,2}))?))", re.IGNORECASE),
-        re.compile(r"\b(((AFH)|(Air ?Force ?Handbook)) ?\)? ?((1)|(([0-9]{1,2} ?- ?[0-9]{3,4})(( ?\( ?I ?\))|( ?V ?[0-9]{1,2})|( ?, ?Vol(ume)? ?[0-9]{1,2}))?)))",
-        re.IGNORECASE)
-    )
-    ref_dict["HAFMD"]=(
-        re.compile(r"[0-9] ?- ?[0-9]{1,2}( ?ADDENDUM ?[A-Z])?", re.IGNORECASE),
-        re.compile(r"\b(((HAFMD)|(HEADQUARTERS ?AIR ?FORCE ?MISSION ?DIRECTIVE)) ?\)? ?[0-9] ?- ?[0-9]{1,2}( ?ADDENDUM ?[A-Z])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AFPAM"]=(
-        re.compile(r"(\( ?I ?\) ?)?[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((AFPAM)|(Air ?Force ?Pamphlet)) ?\)? ?(\( ?I ?\) ?)?[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AFMD"]=(
-        re.compile(r"[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b(((AFMD)|(Air ?Force ?MISSION ?DIRECTIVE)) ?\)? ?[0-9]{1,2})", re.IGNORECASE)
-    )
-    ref_dict["AFM"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{2}", re.IGNORECASE),
-        re.compile(r"\b(((AFM)|(Air ?Force ?Manual)) ?\)? ?[0-9]{2} ?- ?[0-9]{2})",
-        re.IGNORECASE)
-    )
-    ref_dict["HOI"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b(((HOI)|(HEADQUARTERS ?OPERATING ?INSTRUCTION)) ?\)? ?[0-9]{2} ?- ?[0-9]{1,2})",
-        re.IGNORECASE)
-    )
-    ref_dict["AFJQS"]=(
-        re.compile(r"[0-9][0-9A-Z]{4}( ?- ?[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((AFJQS)|(Air ?Force ?Job ?Qualification ?Standard)) ?\)? ?[0-9][0-9A-Z]{4}( ?- ?[0-9])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AFJI"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{3,4}", re.IGNORECASE),
-        re.compile(r"\b(((AFJI)|(Air ?Force ?Joint ?Instruction)) ?\)? ?[0-9]{2} ?- ?[0-9]{3,4})",
-        re.IGNORECASE)
-    )
-    ref_dict["AFGM"]=(
-        re.compile(r"[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}([0-9] ?- ?[0-9]{2})?", re.IGNORECASE),
-        re.compile(r"\b(((AFGM)|(Air ?Force ?Guidance ?Memorandum)) ?\)? ?[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}([0-9] ?- ?[0-9]{2})?)",
-        re.IGNORECASE)
-    )
-    ref_dict["DAFI"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((DAFI)|(Department ?of ?the ?Air ?Force ?Instruction)) ?\)? ?[0-9]{2} ?- ?[0-9]{3,4}( ?V ?[0-9])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AF"]=(
-        re.compile(r"[0-9]{1,4}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((AF)|(Air ?Force)) ?\)? ?(Form ?)?[0-9]{1,4}[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["SF"]=(
-        re.compile(r"[0-9]{2,4}( ?- ?[0-9])?[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b((SF) ?\)? ?[0-9]{2,4}( ?- ?[0-9])?[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["AFPM"]=(
-        re.compile(r"[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}", re.IGNORECASE),
-        re.compile(r"\b(((AFPM)|(Air ?Force ?Policy ?Memorandum)) ?\)? ?[0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2})",
-        re.IGNORECASE)
-    )
-    ref_dict["AFJMAN"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b(((AFJMAN)|(Air ?Force ?Joint\sManual)) ?\)? ?[0-9]{2} ?- ?[0-9]{3})",
-        re.IGNORECASE)
-    )
-    ref_dict["JTA"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{1,3}", re.IGNORECASE),
-        re.compile(r"\b(((JTA)|(Joint ?Table ?of\sAllowances?)) ?\)? ?[0-9]{2} ?- ?[0-9]{1,3})",
-        re.IGNORECASE)
-    )
-    ref_dict["DAFPD"]=(
-        re.compile(r"[0-9]{2} ?- ?[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b(((DAFPD)|(Department ?of ?\the ?Air ?Force ?Policy ?Directive)) ?\)? ?[0-9]{2} ?- ?[0-9]{1,2})",
-        re.IGNORECASE)
-    )
-    ref_dict["MCO"]=(
-        re.compile(r"P?[0-9]{4,5}[A-Z]?\.[0-9]{1,3}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((MCO)|(Marine ?Corps ?Orders?)) ?\)? ?P?[0-9]{4,5}[A-Z]?\.[0-9]{1,3}[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["MCBUL"]=(
-        re.compile(r"[0-9]{4,5}", re.IGNORECASE),
-        re.compile(r"\b(((MCBUL)|(MARINE ?CORPS ?BULLETIN)) ?\)? ?[0-9]{4,5})",
-        re.IGNORECASE)
-    )
-    ref_dict["NAVMC"]=(
-        re.compile(r"[0-9]{4}((\.[0-9]{1,3}[A-Z]?)|( ?- ?[A-Z]))?", re.IGNORECASE),
-        re.compile(r"\b((NAVMC) ?\)? ?[0-9]{4}((\.[0-9]{1,3}[A-Z]?)|( ?- ?[A-Z]))?)",
-        re.IGNORECASE)
-    )
-    ref_dict["NAVMC DIR"]=(
-        re.compile(r"[0-9]{4}.[0-9]{1,3}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((NAVMC ?DIR)|(NAVMC ?Directive)) ?\)? ?[0-9]{4}.[0-9]{1,3}[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["MCRP"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{1,2}[A-Z]?(\.[0-9]{1-2}[A-Z]?)?", re.IGNORECASE),
-        re.compile(r"\b(((MCRP)|(MARINE ?CORPS ?Reference ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{1,2}[A-Z]?(\.[0-9]{1-2}[A-Z]?)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["MCTP"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{2}[A-Z]", re.IGNORECASE),
-        re.compile(r"\b(((MCTP)|(MARINE ?CORPS ?Tactical ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{2}[A-Z])",
-        re.IGNORECASE)
-    )
-    ref_dict["MCWP"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{2}(\.[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((MCWP)|(MARINE ?CORPS ?Warfighting ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{2}(\.[0-9])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["MCDP"]=(
-        re.compile(r"[0-9]( ?- ?[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((MCDP)|(MARINE ?CORPS ?Doctrinal ?Publication)) ?\)? ?[0-9]( ?- ?[0-9])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["MCIP"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{2}([A-Z]{1,2})?(\.?[0-9]{1,2}[A-Z]?)?", re.IGNORECASE),
-        re.compile(r"\b(((MCIP)|(MARINE ?CORPS ?Interim ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{2}([A-Z]{1,2})?(\.?[0-9]{1,2}[A-Z]?)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["FMFRP"]=(
-        re.compile(r"[0-9]{1,2} ?- ?[0-9]{1,3}( ?- ?I+)?", re.IGNORECASE),
-        re.compile(r"\b(((FMFRP)|(Fleet ?Marine ?Force ?Reference ?Publication)) ?\)? ?[0-9]{1,2} ?- ?[0-9]{1,3}( ?- ?I+)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["FMFM"]=(
-        re.compile(r"[0-9] ?- ?[0-9]{1,2}( ?- ?[0-9])?", re.IGNORECASE),
-        re.compile(r"\b(((FMFM)|(Fleet ?Marine ?Force ?Manuals?)) ?\)? ?[0-9] ?- ?[0-9]{1,2}( ?- ?[0-9])?)",
-        re.IGNORECASE)
-    )
-    ref_dict["IRM"]=(
-        re.compile(r"(- ?)?[0-9]{4} ?- ?[0-9]{2}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((IRM)|(Information ?Resource ?Management)) ?\)? ?(- ?)?[0-9]{4} ?- ?[0-9]{2}[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["SECNAVINST"]=(
-        re.compile(r"[0-9]{4}\.[0-9]{1,2}[A-Z]?", re.IGNORECASE),
-        re.compile(r"\b(((SECNAVINST)|(SECNAV ?INSTRUCTION)) ?\)? ?[0-9]{4}\.[0-9]{1,2}[A-Z]?)",
-        re.IGNORECASE)
-    )
-    ref_dict["SECNAV"]=(
-        re.compile(r"M ?- ?[0-9]{4}\.[0-9]{1,2}", re.IGNORECASE),
-        re.compile(r"\b((SECNAV) ?\)? ?M ?- ?[0-9]{4}\.[0-9]{1,2})",
-        re.IGNORECASE)
-    )
-    ref_dict["NAVSUP"]=(
-        re.compile(r"((P ?- ?)|(Publication ?))[0-9]{3}", re.IGNORECASE),
-        re.compile(r"\b((NAVSUP) ?\)? ?((P ?- ?)|(Publication ?))[0-9]{3})",
-        re.IGNORECASE)
-    )
-    ref_dict["JAGINST"]=(
-        re.compile(r"[0-9]{4,5}(\.[0-9]{1,2}[A-Z]?)?", re.IGNORECASE),
-        re.compile(r"\b(((JAGINST)|(JAG ?Instruction)) ?\)? ?[0-9]{4,5}(\.[0-9]{1,2}[A-Z]?)?)",
-        re.IGNORECASE)
-    )
-    ref_dict["OMBM"]=(
-        re.compile(r"M-[0-9]{2}-[0-9]{2}", re.IGNORECASE),
-        re.compile(r"((M-[0-9]{2}-[0-9]{2}))",
-        re.IGNORECASE)
+    ref_dict["DoD"] = re.compile(
+        r"\b(?:dod ?placeholder|dod) ?\)? ?((?:[A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(?:-[A-Z]+)?E?)",
+        re.IGNORECASE,
     )
+    ref_dict["DoDD"] = re.compile(
+        r"\b(?:dod ?directives?|dodd) ?\)? ?((?:[A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(?:-[A-Z]+)?E?)",
+        re.IGNORECASE,
+    )
+    ref_dict["DoDI"] = re.compile(
+        r"\b(?:dod ?instruction|dodi) ?\)? ?((?:[A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3} ?(?:-[A-Z]+)?E?)",
+        re.IGNORECASE,
+    )
+    ref_dict["DoDM"] = re.compile(
+        r"\b(?:dod ?manual|dodm) ?\)? ?((?:[A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}(?: ?,* ?Volume ?[0-9]+| ?- ?V[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["DTM"] = re.compile(
+        r"\b(?:DTM|DT ?Memorandum) ?\)? ?-? ?([0-9]{2} ?- ?[0-9]{3})",
+        re.IGNORECASE,
+    )
+    ref_dict["AI"] = re.compile(
+        r"\b(?:administrative ?instruction|ai) ?\)? ?([0-9]+)", re.IGNORECASE
+    )
+    ref_dict["Title"] = re.compile(r"\bTitle ?([0-9]{1,2})", re.IGNORECASE)
+    ref_dict["ICD"] = re.compile(
+        r"\b(?:Intelligence ?Community ?Directive|ICD) ?\)? ?([0-9]{1,3})",
+        re.IGNORECASE,
+    )
+    ref_dict["ICPG"] = re.compile(
+        r"\bicpg ?((?:[A-Z]+-)?[0-9]{3}\. ?[0-9]{1,3} ?(?:-[A-Z]+)?E?)",
+        re.IGNORECASE,
+    )
+    ref_dict["ICPM"] = re.compile(
+        r"\bicpm ?([0-9]{4}- ?[0-9]{3}- ?[0-9]{1})", re.IGNORECASE
+    )
+    ref_dict["CJCSI"] = re.compile(
+        r"\b(?:cjcs ?instruction|cjcsi) ?\)? ?((?:[A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["CJCSM"] = re.compile(
+        r"\b(?:cjcs ?manual|cjcsm) ?\)? ?((?:[A-Z]+-)?[0-9]{4}\. ?[0-9]{1,3}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["CJCSG"] = re.compile(
+        r"\b(?:cjcs ?gde|cjcsg) ?\)? ?((?:[A-Z]+-)?[0-9]{4} ?[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["CJCSN"] = re.compile(
+        r"\b(?:cjcs ?notice|cjcsn) ?\)? ?((?:[A-Z]+-)?[0-9]{4}(?:\. ?[0-9]{0,3}[A-Z]?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["JP"] = re.compile(
+        r"\b(?:joint ?publication|jp) ?\)? ?((?:[A-Z]+-)?[0-9]{1,2}-[0-9]{1,3}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["DCID"] = re.compile(
+        r"\b(?:Director ?of ?Central ?Intelligence ?Directives|DCID) ?\)? ?([0-9]\/[0-9]{1,2}P?)",
+        re.IGNORECASE,
+    )
+    ref_dict["EO"] = re.compile(
+        r"\b(?:Executive ?Order|EO|E\. ?O\. ?) ?\)? ?([0-9]{5})", re.IGNORECASE
+    )
+    ref_dict["AR"] = re.compile(
+        r"\b(?:AR|Army ?regulations?) ?\)? ?([0-9]{1,3} ?- ?[0-9]{1,3}(?: ?- ?[0-9]{1,3})?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AGO"] = re.compile(
+        r"\b(?:AGO|Army ?General ?Orders?) ?\)? ?((?:19|20)[0-9]{2} ?- ?[0-9]{2,3})",
+        re.IGNORECASE,
+    )
+    ref_dict["ADP"] = re.compile(
+        r"\b(?:ADP|Army ?Doctrine ?Publications?) ?\)? ?(1|[0-9]{1,2} ?- ?[0-9]{1,2})",
+        re.IGNORECASE,
+    )
+    ref_dict["PAM"] = re.compile(
+        r"\b(?:PAM|DA ?Pam(?:phlets?)?) ?\)? ?([0-9]{1,3} ?- ?[0-9]{1,3}(?: ?- ?[0-9]{1,3})?)",
+        re.IGNORECASE,
+    )
+    ref_dict["ATP"] = re.compile(
+        r"\b(?:ATP|Army ?Techniques ?Publications?) ?\)? ?([0-9] ?- ?[0-9]{1,2}(?:\.[0-9]{1,2}(?: ?- ?[0-9]{1,2})?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["ARMY"] = re.compile(
+        r"\b(?:ARMY ?DIR|ARMY ?Directives?) ?\)? ?(20[0-9]{2} ?- ?[0-9]{2}(?: ?- ?[0-9]{1,2})?)",
+        re.IGNORECASE,
+    )
+    ref_dict["TC"] = re.compile(
+        r"\b(?:TC|Training ?Circular) ?\)? ?([0-9]{1,2} ?- ?(?:HEAT|[0-9]{1,3}(?: ?(?:\.|- ?[0-9]{1,3}(?: ?- ?[0-9])?A?)?)))",
+        re.IGNORECASE,
+    )
+    ref_dict["STP"] = re.compile(
+        r"\b(?:STP|Soldier ?Training ?Publication) ?\)? ?([0-9]{1,2} ?- ?[A-Z0-9]{1,6}(?: ?- ?[A-Z]{2,4}(?: ?- ?[A-Z]{2})?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["TB"] = re.compile(
+        r"\b(?:TB|Technical ?Bulletins?) ?\)? ?(ENG ?[0-9]{2,3}|[0-9]{3} ?- ?[0-9]{1,2}|MED ?[0-9]{1,3}(?:- ?[0-9]{1,2})?|[0-9]{1,2} ?- ?[0-9]{3,4} ?(?:- ?(?:[0-9]{3} ?- ?[0-9]{2})|(?:[A-Z]{3})?))",
+        re.IGNORECASE,
+    )
+    ref_dict["DA"] = re.compile(
+        r"\b(?:DA ?MEMO|DA ?MEMORANDUMS?) ?\)? ?([0-9]{1,3} ?- ?[0-9]{1,3}(?: ?- ?[0-9]{2})?)",
+        re.IGNORECASE,
+    )
+    ref_dict["FM"] = re.compile(
+        r"\b(?:FM|Field ?Manual) ?\)? ?([0-9]{1,3} ?- ?[0-9]{1,3}(?: ?(?:\.|-) ?[0-9]{1,2}(?: ?- ?[A-Z]{2})?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["GTA"] = re.compile(
+        r"\b(?:GTA|Graphic ?Training ?Aid) ?\)? ?([0-9]{2} ?- ?[0-9]{2}(?: ?- ?[0-9]{3})?[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["HQDA"] = re.compile(
+        r"\bHQDA ?POLICY ?NOTICE ?([0-9]{1,3} ?- ?[0-9]{1})", re.IGNORECASE
+    )
+    ref_dict["CTA"] = re.compile(
+        r"\b(?:CTA|Common ?Table ?of ?Allowances?) ?\)? ?([[0-9]{1,2} ?- ?[0-9]{3})",
+        re.IGNORECASE,
+    )
+    ref_dict["ATTP"] = re.compile(
+        r"\b(?:ATTP|ARMY ?TACTICS,? ?TECHNIQUES ?AND ?PROCEDURES?) ?\)? ?([0-9]{1} ?- ?[0-9]{2} ?\. ?[0-9]{2})",
+        re.IGNORECASE,
+    )
+    ref_dict["TM"] = re.compile(
+        r"\b(?:TM|Technical ?Manuals?) ?\)? ?([0-9]{1,2} ?- ?[A-Z0-9]{1,4}(?:\.[0-9]{2})?(?: ?- ?[A-Z0-9&]{1,4})*)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFI"] = re.compile(
+        r"\b(?:AFI|Air ?Force ?Instructions?) ?\)? ?([0-9]{1,2} ?- ?[A-Z0-9-_]+)",
+        re.IGNORECASE,
+    )
+    ref_dict["CFETP"] = re.compile(
+        r"\b(?:CFETP|CAREER ?FIELD ?EDUCATION ?(?:AND|&) ?TRAINING ?PLAN) ?\)? ?([A-Z0-9]*[0-9][A-Z0-9-_]+)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFMAN"] = re.compile(
+        r"\b(?:AFMAN|AIR ?FORCE ?MANUAL) ?\)? ?([0-9]{2} ?- ?[A-Z0-9-_]+)",
+        re.IGNORECASE,
+    )
+    ref_dict["QTP"] = re.compile(
+        r"\b(?:QTP|QUALIFICATION ?TRAINING ?PACKAGE) ?\)? ?([0-9][0-9A-Z]{1,6}(?: ?- ?[0-9A-Z]{1,6}){0,2})",
+        re.IGNORECASE,
+    )
+    ref_dict["AFPD"] = re.compile(
+        r"\b(?:AFPD|AIR ?FORCE ?POLICY ?DIRECTIVE) ?\)? ?(1|[0-9]{2} ?- ?[0-9]{1,2}(?: ?- ?[A-Z])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFTTP"] = re.compile(
+        r"\b(?:AFTTP|Air ?Force ?Tactics?,? ?Techniques?,? ?(?:and|&)? ?Procedures?) ?\)? ?([0-9] ?- ?[0-9]{1,2}(?:\.[0-9]{1,2})?(?:V[0-9]|_[A-Z]{2})?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFVA"] = re.compile(
+        r"\b(?:AFVA|Air ?Force ?Visual ?Aids?) ?\)? ?([0-9]{1,2} ?- ?[0-9]{1,4})",
+        re.IGNORECASE,
+    )
+    ref_dict["AFH"] = re.compile(
+        r"\b(?:AFH|Air ?Force ?Handbook) ?\)? ?(1|[0-9]{1,2} ?- ?[0-9]{3,4}(?: ?\( ?I ?\)| ?V ?[0-9]{1,2}|(?: ?, ? ?Vol(?:ume)? ?[0-9]{1,2}))?)",
+        re.IGNORECASE,
+    )
+    ref_dict["HAFMD"] = re.compile(
+        r"\b(?:HAFMD|HEADQUARTERS ?AIR ?FORCE ?MISSION ?DIRECTIVE) ?\)? ?([0-9] ?- ?[0-9]{1,2}(?: ?ADDENDUM ?[A-Z])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFPAM"] = re.compile(
+        r"\b(?:AFPAM|Air ?Force ?Pamphlet) ?\)? ?((?:\( ?I ?\) ?)?[0-9]{2} ?- ?[0-9]{3,4}(?: ?V ?[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFMD"] = re.compile(
+        r"\b(?:AFMD|Air ?Force ?MISSION ?DIRECTIVE) ?\)? ?([0-9]{1,2})",
+        re.IGNORECASE,
+    )
+    ref_dict["AFM"] = re.compile(
+        r"\b(?:AFM|Air ?Force ?Manual) ?\)? ?([0-9]{2} ?- ?[0-9]{2})",
+        re.IGNORECASE,
+    )
+    ref_dict["HOI"] = re.compile(
+        r"\b(?:HOI|HEADQUARTERS ?OPERATING ?INSTRUCTION) ?\)? ?([0-9]{2} ?- ?[0-9]{1,2})",
+        re.IGNORECASE,
+    )
+    ref_dict["AFJQS"] = re.compile(
+        r"\b(?:AFJQS|Air ?Force ?Job ?Qualification ?Standard) ?\)? ?([0-9][0-9A-Z]{4}(?: ?- ?[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AFJI"] = re.compile(
+        r"\b(?:AFJI|Air ?Force ?Joint ?Instruction) ?\)? ?([0-9]{2} ?- ?[0-9]{3,4})",
+        re.IGNORECASE,
+    )
+    ref_dict["AFGM"] = re.compile(
+        r"\b(?:AFGM|Air ?Force ?Guidance ?Memorandum) ?\)? ?([0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2}(?:[0-9] ?- ?[0-9]{2})?)",
+        re.IGNORECASE,
+    )
+    ref_dict["DAFI"] = re.compile(
+        r"\b(?:DAFI|Department ?of ?the ?Air ?Force ?Instruction) ?\)? ?([0-9]{2} ?- ?[0-9]{3,4}(?: ?V ?[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["AF"] = re.compile(
+        r"\b(?:AF|Air ?Force) ?\)? ?(?:Form ?)?([0-9]{1,4}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["SF"] = re.compile(
+        r"\bSF ?\)? ?([0-9]{2,4}(?: ?- ?[0-9])?[A-Z]?)", re.IGNORECASE
+    )
+    ref_dict["AFPM"] = re.compile(
+        r"\b(?:AFPM|Air ?Force ?Policy ?Memorandum) ?\)? ?([0-9]{4} ?- ?[0-9]{2} ?- ?[0-9]{2})",
+        re.IGNORECASE,
+    )
+    ref_dict["AFJMAN"] = re.compile(
+        r"\b(?:AFJMAN|Air ?Force ?Joint Manual) ?\)? ?([0-9]{2} ?- ?[0-9]{3})",
+        re.IGNORECASE,
+    )
+    ref_dict["JTA"] = re.compile(
+        r"\b(?:JTA|Joint ?Table ?of Allowances?) ?\)? ?([0-9]{2} ?- ?[0-9]{1,3})",
+        re.IGNORECASE,
+    )
+    ref_dict["DAFPD"] = re.compile(
+        r"\b(?:DAFPD|Department ?of ?\the ?Air ?Force ?Policy ?Directive) ?\)? ?([0-9]{2} ?- ?[0-9]{1,2})",
+        re.IGNORECASE,
+    )
+    ref_dict["MCO"] = re.compile(
+        r"\b(?:MCO|Marine ?Corps ?Orders?) ?\)? ?(P?[0-9]{4,5}[A-Z]?\.[0-9]{1,3}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["MCBUL"] = re.compile(
+        r"\b(?:MCBUL|MARINE ?CORPS ?BULLETIN) ?\)? ?([0-9]{4,5})",
+        re.IGNORECASE,
+    )
+    ref_dict["NAVMC"] = re.compile(
+        r"\bNAVMC ?\)? ?([0-9]{4}(?:\.[0-9]{1,3}[A-Z]?| ?- ?[A-Z])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["NAVMC DIR"] = re.compile(
+        r"\b(?:NAVMC ?DIR|NAVMC ?Directive) ?\)? ?([0-9]{4}.[0-9]{1,3}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["MCRP"] = re.compile(
+        r"\b(?:MCRP|MARINE ?CORPS ?Reference ?Publication) ?\)? ?([0-9]{1,2} ?- ?[0-9]{1,2}[A-Z]?(?:\.[0-9]{1-2}[A-Z]?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["MCTP"] = re.compile(
+        r"\b(?:MCTP|MARINE ?CORPS ?Tactical ?Publication) ?\)? ?([0-9]{1,2} ?- ?[0-9]{2}[A-Z])",
+        re.IGNORECASE,
+    )
+    ref_dict["MCWP"] = re.compile(
+        r"\b(?:MCWP|MARINE ?CORPS ?Warfighting ?Publication) ?\)? ?([0-9]{1,2} ?- ?[0-9]{1,2}(?:\.[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["MCDP"] = re.compile(
+        r"\b(?:MCDP|MARINE ?CORPS ?Doctrinal ?Publication) ?\)? ?([0-9](?: ?- ?[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["MCIP"] = re.compile(
+        r"\b(?:MCIP|MARINE ?CORPS ?Interim ?Publication) ?\)? ?([0-9]{1,2} ?- ?[0-9]{2}(?:[A-Z]{1,2})?(?:\.?[0-9]{1,2}[A-Z]?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["FMFRP"] = re.compile(
+        r"\b(?:FMFRP|Fleet ?Marine ?Force ?Reference ?Publication) ?\)? ?([0-9]{1,2} ?- ?[0-9]{1,3}(?: ?- ?I+)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["FMFM"] = re.compile(
+        r"\b(?:FMFM|Fleet ?Marine ?Force ?Manuals?) ?\)? ?([0-9] ?- ?[0-9]{1,2}(?: ?- ?[0-9])?)",
+        re.IGNORECASE,
+    )
+    ref_dict["IRM"] = re.compile(
+        r"\b(?:IRM|Information ?Resource ?Management) ?\)? ?((?:- ?)?[0-9]{4} ?- ?[0-9]{2}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["SECNAVINST"] = re.compile(
+        r"\b(?:SECNAVINST|SECNAV ?INSTRUCTION) ?\)? ?([0-9]{4}\.[0-9]{1,2}[A-Z]?)",
+        re.IGNORECASE,
+    )
+    ref_dict["SECNAV"] = re.compile(
+        r"\bSECNAV ?\)? ?(M ?- ?[0-9]{4}\.[0-9]{1,2})", re.IGNORECASE
+    )
+    ref_dict["NAVSUP"] = re.compile(
+        r"\bNAVSUP ?\)? ?((?:P ?- ?|Publication ?)[0-9]{3})", re.IGNORECASE
+    )
+    ref_dict["JAGINST"] = re.compile(
+        r"\b(?:JAGINST|JAG ?Instruction) ?\)? ?([0-9]{4,5}(?:\.[0-9]{1,2}[A-Z]?)?)",
+        re.IGNORECASE,
+    )
+    ref_dict["OMBM"] = re.compile(r"(M-[0-9]{2}-[0-9]{2})", re.IGNORECASE)
+
     return ref_dict

--- a/common/document_parser/test_ref.py
+++ b/common/document_parser/test_ref.py
@@ -1,382 +1,464 @@
-import logging
 from common.document_parser.ref_utils import make_dict
-
-
-logger = logging.getLogger(__name__)
 
 
 ref_regex = make_dict()
 
 def check(check_str, ref_type, exp_result):
     count = 0
-    matches = ref_regex[ref_type][1].findall(check_str)
+    check_str = " ".join(check_str.split())
+    matches = ref_regex[ref_type].findall(check_str)
+
     for match in matches:
-        num_match = ref_regex[ref_type][0].search(match[0])
-        if not num_match:
+        if type(match) == tuple:
+            print(
+                f"ERR: Patterns in `ref_regex` should only have 1 capture "
+                f"group each. Check the pattern for `{ref_type}`."
+            )
             continue
-        ref = (str(ref_type) + " " + str(num_match[0])).strip()
+        elif match == "":
+            continue
         count += 1
-    return count==exp_result
+
+    return count == exp_result
+
 
 def test_dod():
-    check_str= "reference DoD 4160.28-M DoD 7000.14-R DoDD 5134.12 DoDI 4140.01 DoDI 3110.06 DoD"
+    check_str = "reference DoD 4160.28-M DoD 7000.14-R DoDD 5134.12 DoDI 4140.01 DoDI 3110.06 DoD"
     ref_type = "DoD"
     assert check(check_str, ref_type, 2)
 
+
 def test_dodd():
-    check_str= "reference DoD 4160.28-M DoD 7000.14-R DoDD 5134.12 DoDI 4140.01 DoDI 3110.06 DoD Directive 5134.12 DoDD"
+    check_str = "reference DoD 4160.28-M DoD 7000.14-R DoDD 5134.12 DoDI 4140.01 DoDI 3110.06 DoD Directive 5134.12 DoDD"
     ref_type = "DoDD"
     assert check(check_str, ref_type, 2)
 
+
 def test_dodi():
-    check_str= "reference DoD Instruction 3110.06 DoD 4160.28-M DoD 7000.14-R DoDD 5134.12 DoDI 4140.01 DoDI 3110.06 DoDI"
+    check_str = "reference DoD Instruction 3110.06 DoD 4160.28-M DoD 7000.14-R DoDD 5134.12 DoDI 4140.01 DoDI 3110.06 DoDI"
     ref_type = "DoDI"
     assert check(check_str, ref_type, 3)
 
+
 def test_dodm():
-    check_str= "reference DoD 4160.28-M DoD Manual 4140.01 DoDD 5134.12 DoDI 4140.01 DoDM 4100.39 DoDM"
+    check_str = "reference DoD 4160.28-M DoD Manual 4140.01 DoDD 5134.12 DoDI 4140.01 DoDM 4100.39 DoDM"
     ref_type = "DoDM"
     assert check(check_str, ref_type, 2)
 
+
 def test_dtm():
-    check_str= "reference DTM-07-024 DoD Manual 4140.01 DTM 04-021 DoDI 4140.01 DoDM 4100.39 DTM"
+    check_str = "reference DTM-07-024 DoD Manual 4140.01 DTM 04-021 DoDI 4140.01 DoDM 4100.39 DTM"
     ref_type = "DTM"
     assert check(check_str, ref_type, 2)
 
+
 def test_ai():
-    check_str= "reference Administrative Instruction 102 AI DoDD 5134.12 AI 86"
+    check_str = (
+        "reference Administrative Instruction 102 AI DoDD 5134.12 AI 86"
+    )
     ref_type = "AI"
     assert check(check_str, ref_type, 2)
 
+
 def test_title():
-    check_str= "reference Title 10 Title bla bla 12 Title 41"
+    check_str = "reference Title 10 Title bla bla 12 Title 41"
     ref_type = "Title"
     assert check(check_str, ref_type, 2)
 
+
 def test_icd():
-    check_str= "reference ICPG 704.4 ICPM 2006-700-8 ICD 501 ICPG 710.1 Intelligence Community Directive 204 ICD"
+    check_str = "reference ICPG 704.4 ICPM 2006-700-8 ICD 501 ICPG 710.1 Intelligence Community Directive 204 ICD"
     ref_type = "ICD"
     assert check(check_str, ref_type, 2)
 
+
 def test_icpg():
-    check_str= "reference ICPG 704.4 ICPM 2006-700-8 ICD 501 ICPG 710.1 Intelligence Community Directive 204 ICPG"
+    check_str = "reference ICPG 704.4 ICPM 2006-700-8 ICD 501 ICPG 710.1 Intelligence Community Directive 204 ICPG"
     ref_type = "ICPG"
     assert check(check_str, ref_type, 2)
 
+
 def test_icpm():
-    check_str= "reference ICPG 704.4 ICPM 2006-700-8 ICD 501 ICPG 710.1 Intelligence Community Directive 204 ICPM"
+    check_str = "reference ICPG 704.4 ICPM 2006-700-8 ICD 501 ICPG 710.1 Intelligence Community Directive 204 ICPM"
     ref_type = "ICPM"
     assert check(check_str, ref_type, 1)
 
+
 def test_cjcsi():
-    check_str= "reference CJCSI 1001.01  CJCSI 1100.01D DoDI 4140.01 CJCSI 12312321 CJCSM 3150.05D DoDM"
+    check_str = "reference CJCSI 1001.01  CJCSI 1100.01D DoDI 4140.01 CJCSI 12312321 CJCSM 3150.05D DoDM"
     ref_type = "CJCSI"
     assert check(check_str, ref_type, 2)
 
+
 def test_cjcsm():
-    check_str= "reference CJCSM 3105.01 CJCSI 1001.01 CJCSI 1100.01D CJCSM 3150.05D CJCSM"
+    check_str = "reference CJCSM 3105.01 CJCSI 1001.01 CJCSI 1100.01D CJCSM 3150.05D CJCSM"
     ref_type = "CJCSM"
     assert check(check_str, ref_type, 2)
 
+
 def test_cjcsg():
-    check_str= "reference CJCSM 3105.01 CJCS GDE 3401D CJCSI 1100.01D CJCS GDE 5260 CJCSM"
+    check_str = "reference CJCSM 3105.01 CJCS GDE 3401D CJCSI 1100.01D CJCS GDE 5260 CJCSM"
     ref_type = "CJCSG"
     assert check(check_str, ref_type, 2)
 
+
 def test_cjcsn():
-    check_str= "reference CJCSN 3112 CJCSI 1001.01 CJCSN 3130.01 CJCSM 3150.05D CJCSN"
+    check_str = (
+        "reference CJCSN 3112 CJCSI 1001.01 CJCSN 3130.01 CJCSM 3150.05D CJCSN"
+    )
     ref_type = "CJCSN"
     assert check(check_str, ref_type, 2)
 
+
 def test_jp():
-    check_str= "reference DoD 4160.28-M JP 1-02 DoDD 5134.12 JP 4140.01 JP   3-12 DoDM 4100.39 JP"
+    check_str = "reference DoD 4160.28-M JP 1-02 DoDD 5134.12 JP 4140.01 JP   3-12 DoDM 4100.39 JP"
     ref_type = "JP"
     assert check(check_str, ref_type, 2)
 
+
 def test_dcid():
-    check_str= "reference DCID 6/1 DoD DCID 1893 DoDD 5134.12 DoDI 4140.01 DCID 7/6 DCID"
+    check_str = "reference DCID 6/1 DoD DCID 1893 DoDD 5134.12 DoDI 4140.01 DCID 7/6 DCID"
     ref_type = "DCID"
     assert check(check_str, ref_type, 2)
 
+
 def test_eo():
-    check_str= "reference Executive Order 12996 DoD Executive Order 4140.01 Executive   Order 13340 "
+    check_str = "reference Executive Order 12996 DoD Executive Order 4140.01 Executive   Order 13340 "
     ref_type = "EO"
     assert check(check_str, ref_type, 2)
 
+
 def test_ar():
-    check_str= "AR 1-1 AR 1-15 AR 1-202 AR 10-89 AR 11-2 Army Regulations 11-18 AR 25-400-2 AR 380-67 AR 380-381 AR 381-47 AR 381-141 Army Regulation 525-21 Army Regulations (AR) 600-8-3 AR 600-8-10 AR 600-8-101 AR 600-9 AR 601-210"
+    check_str = "AR 1-1 AR 1-15 AR 1-202 AR 10-89 AR 11-2 Army Regulations 11-18 AR 25-400-2 AR 380-67 AR 380-381 AR 381-47 AR 381-141 Army Regulation 525-21 Army Regulations (AR) 600-8-3 AR 600-8-10 AR 600-8-101 AR 600-9 AR 601-210"
     ref_type = "AR"
     assert check(check_str, ref_type, 17)
 
+
 def test_ago():
-    check_str= "AGO 1958-27 AGO 2020 - 31 ARMY general orders (AGO) 2001- 18 ARMY general order 2000- 07 "
+    check_str = "AGO 1958-27 AGO 2020 - 31 ARMY general orders (AGO) 2001- 18 ARMY general order 2000- 07 "
     ref_type = "AGO"
     assert check(check_str, ref_type, 4)
 
+
 def test_adp():
-    check_str= "ADP 1 ADP 3 -0 Army Doctrine Publication 7-0 ADP 1-01"
+    check_str = "ADP 1 ADP 3 -0 Army Doctrine Publication 7-0 ADP 1-01"
     ref_type = "ADP"
     assert check(check_str, ref_type, 4)
 
+
 def test_pam():
-    check_str= "PAM 600-8-101 DA Pamphlet 5-11 PAM 40-507 "
+    check_str = "PAM 600-8-101 DA Pamphlet 5-11 PAM 40-507 "
     ref_type = "PAM"
     assert check(check_str, ref_type, 3)
 
+
 def test_atp():
-    check_str= "ATP 1-0.1 ATP 1-20 ATP 2-22.9-2 Army Techniques Publication 1-05.03 "
+    check_str = (
+        "ATP 1-0.1 ATP 1-20 ATP 2-22.9-2 Army Techniques Publication 1-05.03 "
+    )
     ref_type = "ATP"
     assert check(check_str, ref_type, 4)
 
+
 def test_army_dir():
-    check_str= "army DIR 2020-08 army directive 2019 - 27 army dir"
+    check_str = "army DIR 2020-08 army directive 2019 - 27 army dir"
     ref_type = "ARMY"
     assert check(check_str, ref_type, 2)
 
+
 def test_tc():
-    check_str= "TC 2-91.5A (TC) 3-4 Training circular 3-34.500 TC"
+    check_str = "TC 2-91.5A (TC) 3-4 Training circular 3-34.500 TC"
     ref_type = "TC"
     assert check(check_str, ref_type, 3)
 
+
 def test_stp():
-    check_str= "STP 6-13B24-SM -TG STP 3-CIED - SM-TG STP 6-13II-MQS STP 10-92L14-SM-TG STP 1AB-1948 "
+    check_str = "STP 6-13B24-SM -TG STP 3-CIED - SM-TG STP 6-13II-MQS STP 10-92L14-SM-TG STP 1AB-1948 "
     ref_type = "STP"
     assert check(check_str, ref_type, 4)
 
+
 def test_tb():
-    check_str= "TB 8-6500-MPL TB 8-6515-001-35 TB 38-750-2 TB MED 1 TB MED 284 TB MED 750-1 TB 420-1 TB 420-33 TB ENG 146 TB ENG 62"
+    check_str = "TB 8-6500-MPL TB 8-6515-001-35 TB 38-750-2 TB MED 1 TB MED 284 TB MED 750-1 TB 420-1 TB 420-33 TB ENG 146 TB ENG 62"
     ref_type = "TB"
     assert check(check_str, ref_type, 10)
 
+
 def test_da_memo():
-    check_str= "DA MEMO 600-8-22 DA MEMO 5-5, DA Memorandum 25-53 da memo"
+    check_str = "DA MEMO 600-8-22 DA MEMO 5-5, DA Memorandum 25-53 da memo"
     ref_type = "DA"
     assert check(check_str, ref_type, 3)
 
+
 def test_fm():
-    check_str= "FM 3-01.13 FM 3-13 Field Manual 1-0 FM 3-55.93 FM 3-90-1 FM 101-51-3-CD FM 7-100.1"
+    check_str = "FM 3-01.13 FM 3-13 Field Manual 1-0 FM 3-55.93 FM 3-90-1 FM 101-51-3-CD FM 7-100.1"
     ref_type = "FM"
     assert check(check_str, ref_type, 7)
 
+
 def test_gta():
-    check_str= "GTA 03-04-001A GTA 90-01-028 Graphic Training aid 43-01-103 "
+    check_str = "GTA 03-04-001A GTA 90-01-028 Graphic Training aid 43-01-103 "
     ref_type = "GTA"
     assert check(check_str, ref_type, 3)
 
+
 def test_hqda_policy():
-    check_str= "HQDA POLICY NOTICE 1-1 HQDA POLICY NOTICE 600-4 "
+    check_str = "HQDA POLICY NOTICE 1-1 HQDA POLICY NOTICE 600-4 "
     ref_type = "HQDA"
     assert check(check_str, ref_type, 2)
 
+
 def test_cta():
-    check_str= "CTA 8-100 CTA 50-909 Common Table of Allowances 50-970 "
+    check_str = "CTA 8-100 CTA 50-909 Common Table of Allowances 50-970 "
     ref_type = "CTA"
     assert check(check_str, ref_type, 3)
 
+
 def test_attp():
-    check_str= "reference ATTP 3-06.11	 ATTP 4140.01 "
+    check_str = "reference ATTP 3-06.11	 ATTP 4140.01 "
     ref_type = "ATTP"
     assert check(check_str, ref_type, 1)
 
+
 def test_tm():
-    check_str= "TM 43-0001-26-2 TM 5-3895-332-23P TM 5-3820-255-12&P TM 3-11.42 TM 3-34.48-2 TM 1-5895-308-SUM TM 1-1680-377-13&P-4"
+    check_str = "TM 43-0001-26-2 TM 5-3895-332-23P TM 5-3820-255-12&P TM 3-11.42 TM 3-34.48-2 TM 1-5895-308-SUM TM 1-1680-377-13&P-4"
     ref_type = "TM"
     assert check(check_str, ref_type, 7)
+
 
 def test_afi():
     check_str = "AFI 1-1 AFI 11-2E-3V3 AFI10-2611-O AFI 13-101 AFI 17-2CDAV3"
     ref_type = "AFI"
     assert check(check_str, ref_type, 5)
 
+
 def test_cfetp():
     check_str = "CFETP 15WXC1 CFETP 1N2X1X-CC2 CFETP 3E4X1WG"
     ref_type = "CFETP"
     assert check(check_str, ref_type, 3)
+
 
 def test_afman():
     check_str = "AFMAN 11-2AEV3ADDENDA-A Air Force Manual 11-2C-32BV2 AFMAN10-1004 AFMAN11-2KC-10V3_ADDENDA-A"
     ref_type = "AFMAN"
     assert check(check_str, ref_type, 4)
 
+
 def test_qtp():
     check_str = "QTP 24-3-HAZMAT QTP 43AX-1 (QTP) 24-3-D549"
     ref_type = "QTP"
     assert check(check_str, ref_type, 3)
+
 
 def test_afpd():
     check_str = "AFPD 1 AFPD 4 AFPD 10-10 AFPD 91-1"
     ref_type = "AFPD"
     assert check(check_str, ref_type, 3)
 
+
 def test_afttp():
     check_str = "Air Force Tactics, Techniques, and Procedures (AFTTP) 3-42.32 AFTTP3-4.6_AS AFTTP 3-32.33V1"
     ref_type = "AFTTP"
     assert check(check_str, ref_type, 3)
+
 
 def test_afva():
     check_str = "AFVA 10-241 AFVA 51-1"
     ref_type = "AFVA"
     assert check(check_str, ref_type, 2)
 
+
 def test_afh():
     check_str = "AFH 10-222V1 AFH 1 AFH32-7084"
     ref_type = "AFH"
     assert check(check_str, ref_type, 3)
+
 
 def test_hafmd():
     check_str = "HAFMD 1-2 HAFMD 1-24 Addendum B"
     ref_type = "HAFMD"
     assert check(check_str, ref_type, 2)
 
+
 def test_afpam():
     check_str = "AFPAM 36-2801V1 AFPAM ( I ) 24-237"
     ref_type = "AFPAM"
     assert check(check_str, ref_type, 2)
+
 
 def test_afmd():
     check_str = "AFMD 1 AFMD 28"
     ref_type = "AFMD"
     assert check(check_str, ref_type, 2)
 
+
 def test_afm():
     check_str = "AFM 19-10"
     ref_type = "AFM"
     assert check(check_str, ref_type, 1)
+
 
 def test_HOI():
     check_str = "HOI 10-1 HOI 36-28"
     ref_type = "HOI"
     assert check(check_str, ref_type, 2)
 
+
 def test_afjqs():
     check_str = "AFJQS 5J0X1-2 AFJQS 2XXXX"
     ref_type = "AFJQS"
     assert check(check_str, ref_type, 2)
+
 
 def test_afji():
     check_str = "AFJI 10-411 Air Force Joint Instruction (AFJI) 32-9006"
     ref_type = "AFJI"
     assert check(check_str, ref_type, 2)
 
+
 def test_afgm():
     check_str = "AFGM 2020-36-04 AFGM 2020-63-148-01"
     ref_type = "AFGM"
     assert check(check_str, ref_type, 2)
+
 
 def test_dafi():
     check_str = "DAFI 33-360 DAFI 90-2002 DAFI 48-107V1"
     ref_type = "DAFI"
     assert check(check_str, ref_type, 3)
 
+
 def test_af():
     check_str = "AF 100 AF form 1005"
     ref_type = "AF"
     assert check(check_str, ref_type, 2)
+
 
 def test_sf():
     check_str = "SF 87 SF 708"
     ref_type = "SF"
     assert check(check_str, ref_type, 2)
 
+
 def test_afpm():
     check_str = "AFPM 2019-36-02"
     ref_type = "AFPM"
     assert check(check_str, ref_type, 1)
+
 
 def test_afjman():
     check_str = "AFJMAN 23-209"
     ref_type = "AFJMAN"
     assert check(check_str, ref_type, 1)
 
+
 def test_jta():
     check_str = "JTA 08-02 JTA 74-1"
     ref_type = "JTA"
     assert check(check_str, ref_type, 2)
+
 
 def test_dafpd():
     check_str = "DAFPD 10-36 DAFPD 90-1"
     ref_type = "DAFPD"
     assert check(check_str, ref_type, 2)
 
+
 def test_mco():
     check_str = "MCO 4200.34 MCO P12000.11A MCO 7220R.39"
     ref_type = "MCO"
     assert check(check_str, ref_type, 3)
+
 
 def test_mcbul():
     check_str = "MCBUL 1300 MCBUL 10120"
     ref_type = "MCBUL"
     assert check(check_str, ref_type, 2)
 
+
 def test_navmc():
     check_str = "NAVMC 4500.36B NAVMC 2915"
     ref_type = "NAVMC"
     assert check(check_str, ref_type, 2)
+
 
 def test_navmcdir():
     check_str = "NAVMC DIR 1650.48 NAVMC Directive 5100.8"
     ref_type = "NAVMC DIR"
     assert check(check_str, ref_type, 2)
 
+
 def test_mcrp():
     check_str = "MCRP 1-10.1 MCRP 3-40B.5 MCRP 4-11.3M"
     ref_type = "MCRP"
     assert check(check_str, ref_type, 3)
+
 
 def test_mcwp():
     check_str = "MCWP 3-15.7 MCWP 11-10"
     ref_type = "MCWP"
     assert check(check_str, ref_type, 2)
 
+
 def test_mctp():
     check_str = "MCTP 12-10A MCTP 3-20G"
     ref_type = "MCTP"
     assert check(check_str, ref_type, 2)
+
 
 def test_mcip():
     check_str = "MCIP 3-03DI MCIP 3-03.1i MCIP 3-40G.21"
     ref_type = "MCIP"
     assert check(check_str, ref_type, 3)
 
+
 def test_mcdp():
     check_str = "MCDP 1-1 MCDP 7"
     ref_type = "MCDP"
     assert check(check_str, ref_type, 2)
+
 
 def test_fmfrp():
     check_str = "FMFRP 12-109-II FMFRP 0-53"
     ref_type = "FMFRP"
     assert check(check_str, ref_type, 2)
 
+
 def test_fmfm():
     check_str = "FMFM 6-1"
     ref_type = "FMFM"
     assert check(check_str, ref_type, 1)
+
 
 def test_irm():
     check_str = "IRM-2300-05B IRM 5236-06A IRM-5231-03"
     ref_type = "IRM"
     assert check(check_str, ref_type, 3)
 
+
 def test_secnavinst():
     check_str = "SECNAV Instruction 1640.9C SECNAVINST 5210.60"
     ref_type = "SECNAVINST"
     assert check(check_str, ref_type, 2)
+
 
 def test_secnav():
     check_str = "SECNAV M-1650.1 SECNAV M-5210.2"
     ref_type = "SECNAV"
     assert check(check_str, ref_type, 2)
 
+
 def test_navsup():
     check_str = "NAVSUP P-486 NAVSUP Publication 727"
     ref_type = "NAVSUP"
     assert check(check_str, ref_type, 2)
 
+
 def test_jaginst():
     check_str = "JAGINST 5800.7F JAG INSTRUCTION 1440.1E"
     ref_type = "JAGINST"
     assert check(check_str, ref_type, 2)
+
 
 def test_ombm():
     check_str = "M-00-02 M-07-16 m 18  19"


### PR DESCRIPTION
This PR is part of the effort to enhance parser efficiency and specifically focuses on reference extraction.

## Summary of Changes:

[ref_utils.py](https://github.com/dod-advana/gamechanger-data/blob/dev/common/document_parser/ref_utils.py) creates a dictionary of reference types and regex patterns. 

_Originally_, each value in the dictionary was a tuple of patterns, where the first pattern was identical to the ending part of the second pattern. 
Ex:
```
(
    re.compile(r"(([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE),
    re.compile(r"\b(((dod\s*placeholder)|(dod))\s*\)?\s*([A-Z]+-)?[0-9]{4}\.\s*[0-9]{1,3}\s*(-[A-Z]+)?([E])?)", re.IGNORECASE)
)
```

In [`look_for_general()`](https://github.com/dod-advana/gamechanger-data/blob/dev/common/document_parser/lib/ref_list.py), the second pattern (full reference) was searched for, and then the first pattern (numerical part of a reference) was searched for within the second pattern.

So, **problem number 1** is duplicated regex search.
**Problem number 2** is the patterns contain many (unnecessary) capture groups, and that slows performance. ([reference](https://stackoverflow.com/questions/41444807/why-is-regex-search-slower-with-capturing-groups-in-python))
Both of these problems can be **solved by minimizing the number of capture groups** in the patterns.

_The changes in this PR_ make it so that each pattern has exactly 1 capture group that is the numerical part of a reference.
   

## Time difference:
![reference_extraction_time_improvement](https://user-images.githubusercontent.com/105378552/181646095-b0ce7271-7f59-4544-8cf4-09187d6e9bae.png)

## How to Test:
Run test functions in [test_ref.py](https://github.com/dod-advana/gamechanger-data/blob/parser-efficiency-references/common/document_parser/test_ref.py).