### PR TITLE
page_num -> page_num_i

### DIFF
--- a/common/document_parser/lib/document/field_names.py
+++ b/common/document_parser/lib/document/field_names.py
@@ -6,7 +6,7 @@ class FieldNames:
     PAGE_RAW_TEXT = "p_raw_text"
 
     PARAGRAPHS = "paragraphs"
-    PAGE_NUM = "page_num"
+    PAGE_NUM = "page_num_i"
     PAR_COUNT = "par_count_i"  # Paragraph index within the given page
     PAR_INC_COUNT = (
         "par_inc_count"  # Paragraph index within the entire document


### PR DESCRIPTION
- `page_num` -> `page_num_i` since the frontend is querying `page_num_i` specifically
- adding `orgs_rs`, `text_length_r`, and `kw_doc_score_r`. these were removed previously, adding them back in until frontend can make changes to remove them from their queries