### PR TITLE
Standardize Entities During Extraction

### DIFF
--- a/common/document_parser/lib/entities_utils.py
+++ b/common/document_parser/lib/entities_utils.py
@@ -63,8 +63,8 @@ def make_entities_lookup_dict(
                 for i in df.index:
                     update_ents_dict(df.loc[i, "Parent"], "ORG", ents_dict)
             elif col == "Aliases":
-                for ents in df[col]:
-                    update_ents_dict(ents.split(";"), ent_type, ents_dict)
+                for ent_standardized_name, ents in df[["Name",col]].itertuples(index=False):
+                    update_ents_dict(ents.split(";"), ent_type, ents_dict, ent_standardized_name)
             else:
                 for ent in df[col]:
                     update_ents_dict(ent, ent_type, ents_dict)
@@ -78,7 +78,7 @@ def make_entities_lookup_dict(
     return ents_dict
 
 
-def update_ents_dict(ents, ent_type, ents_dict):
+def update_ents_dict(ents, ent_type, ents_dict, ent_standardized_name=None):
     """Helper function used in make_entities_lookup_dict(). Used to add values 
     to the entities lookup dictionary.
 
@@ -86,6 +86,8 @@ def update_ents_dict(ents, ent_type, ents_dict):
         ents (str or list of str): Entities to add to ents_dict.
         ent_type (str): The type of entity/ entities being added to ents_dict.
         ent_dict (dict): Dictionary such that keys (str) are
+        ent_standardized_name (str): Standardized name of the entity (specifically for aliases) that should be used
+                                     in the name mapping
     """
     if type(ents) == str:
         ents = [ents]
@@ -95,7 +97,7 @@ def update_ents_dict(ents, ent_type, ents_dict):
         ent_alphanum = replace_nonalpha_chars(ent, "")
         if ent_alphanum != "":
             ents_dict[ent_alphanum] = {
-                "raw_ent": ent,
+                "raw_ent": ent if not ent_standardized_name else ent_standardized_name,
                 "ent_type": ent_type,
             }
 


### PR DESCRIPTION
This code update modifies the logic used to created the `ENTITIES_LOOKUP_DICT` (used for mapping entities to a normalized name) such that for aliases the mapping is the actual `Name` (non-alias) for the entity. 

To test:
* Pull down this branch and pip install the gamechanger-data package in your env
* Option A: Create a test python scrip including the following:
```
from common.document_parser.lib import entities
# This should print the standardized `Name` value for the row in Graph Relations
print(entities.ENTITIES_LOOKUP_DICT.get(entities.replace_nonalpha_chars("GCCS-J")))
## `GCCS-J` can be replaced by any alias and this should work
```
* Option B: Run pdf-to-json pipeline and verify that entities are being extracted with their standardized name e.g., if `DOD` is in the document, this should expand to `United States Department of Defense`