### PR TITLE
Patch Dockerfiles. Update version of packages for rhel8 reqs

### DIFF
--- a/dataPipelines/gc_elasticsearch_publisher/__init__.py
+++ b/dataPipelines/gc_elasticsearch_publisher/__init__.py
@@ -1,4 +1,4 @@
 from gamechangerml import DATA_PATH
 import os
 
-DEFAULT_ENTITIY_CSV_PATH = os.path.join(DATA_PATH, "combined_entities.csv")
+DEFAULT_ENTITIY_CSV_PATH = os.path.join(DATA_PATH, "features", "combined_entities.csv")

--- a/dev_tools/docker/k8s/rhel7.Dockerfile
+++ b/dev_tools/docker/k8s/rhel7.Dockerfile
@@ -25,7 +25,7 @@ ENV LANG="C.utf8" \
 
 # Additional Repos
 RUN \
-      rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG \
+      rpm --import https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG \
   &&  yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   &&  rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL \
   &&  rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 \
@@ -175,7 +175,7 @@ RUN \
     "${APP_SRC}"
 
 # setup venv
-COPY ./dev_tools/requirements/requirements.txt /tmp/requirements.txt
+COPY ./dev_tools/requirements/gc-venv-currnet.txt /tmp/requirements.txt
 RUN \
       scl enable "rh-python${PYTHON_VERSION}" -- python -m venv "${APP_VENV}" --prompt app-root \
   &&  "${APP_VENV}/bin/python" -m pip install --upgrade --no-cache-dir pip setuptools wheel \

--- a/dev_tools/docker/k8s/rhel8.Dockerfile
+++ b/dev_tools/docker/k8s/rhel8.Dockerfile
@@ -24,7 +24,7 @@ ENV LANG="C.utf8" \
 
 # Additional Repos
 RUN \
-      rpm --import https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG \
+      rpm --import https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG \
   &&  dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   &&  rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL \
   &&  rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 \
@@ -32,8 +32,9 @@ RUN \
 
 # COMMON Packages & More Particular RPM Dependcies
 RUN \
-      dnf install -y glibc-locale-source.x86_64 \
-  &&  dnf install -y \
+      dnf update -y \
+  &&  dnf install -y glibc-locale-source.x86_64 \
+  &&  dnf install -y --skip-broken \
         zip \
         unzip \
         gzip \
@@ -59,7 +60,7 @@ RUN \
         python38-Cython \
         "postgresql13" \
         "postgresql13-devel" \
-        libpq5-devel-13.4-42PGDG.rhel8 \
+        libpq5-devel \
         openblas \
         openblas-threads \
         diffutils \
@@ -188,7 +189,7 @@ RUN \
     "${APP_SRC}"
 
 # setup venv
-COPY ./dev_tools/requirements/requirements.txt /tmp/requirements.txt
+COPY ./dev_tools/requirements/rhel8.locked.requirements.txt /tmp/requirements.txt
 RUN \
       python3 -m venv "${APP_VENV}" --prompt app-root \
   &&  "${APP_VENV}/bin/python" -m pip install --upgrade --no-cache-dir pip setuptools wheel \

--- a/dev_tools/requirements/rhel8.locked.requirements.txt
+++ b/dev_tools/requirements/rhel8.locked.requirements.txt
@@ -1,7 +1,7 @@
 absl-py==0.15.0
 annoy==1.17.0
 anyio==3.3.4
-arabic-reshaper==2.1.3
+arabic-reshaper==2.1.4
 astunparse==1.6.3
 attrs==21.2.0
 beautifulsoup4==4.10.0
@@ -35,9 +35,9 @@ filetype==1.0.8
 flatbuffers==1.12
 future==0.18.2
 fuzzywuzzy==0.18.0
-gamechangerml @ https://github.com/dod-advana/gamechanger-ml/archive/refs/heads/task/UOT-117914.zip
+gamechangerml @ https://github.com/shanedell/gamechanger-ml/archive/refs/heads/patch-reqs.zip
 gast==0.4.0
-gensim==3.8.3
+gensim==4.1.2
 google-auth==2.3.0
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
@@ -48,7 +48,7 @@ h5py==3.1.0
 hnswlib==0.5.2
 html5lib==1.1
 httptools==0.1.2
-huggingface-hub==0.0.19
+huggingface-hub==0.1.2
 humanfriendly==10.0
 idna==3.3
 img2pdf==0.4.2
@@ -83,7 +83,7 @@ pikepdf==2.16.1
 Pillow==8.4.0
 pluggy==1.0.0
 preshed==3.0.5
-protobuf==3.18.1
+protobuf>=3.18.1
 psycopg2==2.8.6
 py==1.10.0
 pyasn1==0.4.8


### PR DESCRIPTION
## Reasoning for PR

Issues addressed that were encountered during the testing of a deployment:

1. URL for RPM-GPG-KEY-PGDG key changed.
2. No file `dev_tools/requirements/requirements.txt`:
    - rhel7 updated with `dev_tools/requirements/gc-venv-current.txt`.
    - rhel8 updated with `dev_tools/requirements/rhel8.locked.requirements.txt`.
3. `dnf update` needed for trying to install postgresql packages, otherwise an error is thrown that they can't be found.
4. libpq5-devel-13.4-42PGDG.rhel8 can't be found, replaced with `libpq5-devel`.
5. `--skip-broken` needed added to avoid error below:
    - `- nothing provides perl(IPC::Run) needed by postgresql13-devel-13.15-3PGDG.rhel8.x86_64 from pgdg13`.
6. gamechangerml dep needed updated to `dev.zip` instead of `task/UOT-117914.zip`. rhel8.locked.requirements.txt updated to not cause conflicts with gamechangerml. This was due to `task/UOT-117914.zip`'s setup.py pointing to python3.6 which is deprecated.
7. For arabic-reshaper, version 2.1.3 was not a listed version, the closest was 2.1.4.
8. Fix path to combined_entities.csv for gc_elasticsearch_publisher data pipeline.

## Branch to base off of

What branch should this PR be based off of? In [gamechanger](https://github.com/dod-advana/gamechanger) it pulls the `dev` branch but should it instead pull `main`? This PR is currently based off of `dev` for that reason but it can be updated to be based on `main` if needed.